### PR TITLE
Add multi-model council support via OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Single-model outputs have blind spots. By running multiple models in parallel an
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-Model Orchestration** | Run parallel drafts from Claude, OpenAI, Gemini, or any provider |
+| **Multi-Model Council** | Run Claude, GPT-4, and Gemini in parallel via single OpenRouter key |
 | **Adversarial Critique** | Built-in critique phase identifies weaknesses and blind spots |
 | **Schema Validation** | JSON schema validation with automatic retry for structured outputs |
 | **Provider Agnostic** | Swap between OpenRouter, direct APIs, or CLI-based providers |
@@ -126,6 +126,14 @@ export OPENROUTER_API_KEY="your-key"
 
 # Run a council task
 council run implementer "Build a login page with OAuth"
+
+# Multi-model council (Claude + GPT-4 + Gemini debating)
+council run architect "Design a caching layer" \
+  --models "anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-pro"
+
+# Or set via environment variable
+export COUNCIL_MODELS="anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-pro"
+council run implementer "Build a login page"
 
 # With health check and verbose output
 council run implementer "Build a login page" --health-check --verbose
@@ -266,6 +274,24 @@ myprovider = "my_package.providers:MyProvider"
 
 ## Configuration
 
+### Environment Variables
+
+```bash
+# Required: OpenRouter API key
+export OPENROUTER_API_KEY="your-key"
+
+# Multi-model council: comma-separated OpenRouter model IDs
+export COUNCIL_MODELS="anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-pro"
+
+# Optional: Model pack overrides for specific task types
+export COUNCIL_MODEL_FAST="anthropic/claude-3-haiku"      # Quick tasks
+export COUNCIL_MODEL_REASONING="anthropic/claude-3-opus"  # Deep analysis
+export COUNCIL_MODEL_CODE="openai/gpt-4o"                 # Code generation
+export COUNCIL_MODEL_CRITIC="anthropic/claude-3.5-sonnet" # Adversarial critique
+```
+
+### Config File
+
 ```yaml
 # ~/.config/llm-council/config.yaml
 providers:
@@ -288,6 +314,7 @@ council config                      # Show configuration
 
 # Options
 --providers, -p    Comma-separated provider list
+--models, -m       Comma-separated OpenRouter model IDs for multi-model council
 --timeout, -t      Timeout in seconds (default: 120)
 --max-retries      Max retry attempts (default: 3)
 --health-check     Run preflight health check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "the-llm-council"
-version = "0.1.0"
+version = "0.2.0"
 description = "Multi-LLM Council Framework for adversarial debate, cross-validation, and structured decision-making"
 readme = "README.md"
 license = "MIT"

--- a/src/llm_council/config/__init__.py
+++ b/src/llm_council/config/__init__.py
@@ -1,0 +1,15 @@
+"""Configuration module for LLM Council."""
+
+from llm_council.config.models import (
+    DEFAULT_COUNCIL_MODELS,
+    ModelPack,
+    get_council_models,
+    get_model_for_pack,
+)
+
+__all__ = [
+    "DEFAULT_COUNCIL_MODELS",
+    "ModelPack",
+    "get_council_models",
+    "get_model_for_pack",
+]

--- a/src/llm_council/config/models.py
+++ b/src/llm_council/config/models.py
@@ -1,0 +1,181 @@
+"""
+Model configuration for multi-model council.
+
+This module handles the configuration of multiple LLM models for council runs.
+Models can be configured via environment variables or passed directly.
+
+Environment Variables:
+    COUNCIL_MODELS: Comma-separated list of OpenRouter model IDs
+        Example: "anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-pro"
+
+    Model pack overrides (optional):
+        COUNCIL_MODEL_FAST: Fast model for quick tasks (default: claude-3-haiku)
+        COUNCIL_MODEL_REASONING: Deep reasoning model (default: claude-3-opus)
+        COUNCIL_MODEL_CODE: Code specialist model (default: gpt-4o)
+        COUNCIL_MODEL_CRITIC: Adversarial critic model (default: claude-3.5-sonnet)
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import ClassVar
+
+
+class ModelPack(str, Enum):
+    """Model pack types for different task categories."""
+
+    FAST = "fast"  # Quick classification, routing
+    REASONING = "reasoning"  # Deep analysis, planning
+    CODE = "code"  # Code generation, implementation
+    CRITIC = "critic"  # Adversarial review, critique
+    DEFAULT = "default"  # General purpose
+
+
+# Default models for each pack (OpenRouter format)
+DEFAULT_MODEL_PACKS: dict[ModelPack, str] = {
+    ModelPack.FAST: "anthropic/claude-3-haiku",
+    ModelPack.REASONING: "anthropic/claude-3-opus",
+    ModelPack.CODE: "openai/gpt-4o",
+    ModelPack.CRITIC: "anthropic/claude-3.5-sonnet",
+    ModelPack.DEFAULT: "anthropic/claude-3.5-sonnet",
+}
+
+# Default council models for multi-model runs
+DEFAULT_COUNCIL_MODELS: list[str] = [
+    "anthropic/claude-3.5-sonnet",
+    "openai/gpt-4o",
+    "google/gemini-pro",
+]
+
+# Environment variable names
+ENV_COUNCIL_MODELS = "COUNCIL_MODELS"
+ENV_MODEL_FAST = "COUNCIL_MODEL_FAST"
+ENV_MODEL_REASONING = "COUNCIL_MODEL_REASONING"
+ENV_MODEL_CODE = "COUNCIL_MODEL_CODE"
+ENV_MODEL_CRITIC = "COUNCIL_MODEL_CRITIC"
+
+
+class ModelConfig:
+    """Configuration for council models."""
+
+    _instance: ClassVar[ModelConfig | None] = None
+
+    def __init__(self) -> None:
+        self._models: list[str] | None = None
+        self._pack_overrides: dict[ModelPack, str] = {}
+        self._load_from_env()
+
+    @classmethod
+    def get_instance(cls) -> ModelConfig:
+        """Get or create the singleton instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton instance (for testing)."""
+        cls._instance = None
+
+    def _load_from_env(self) -> None:
+        """Load configuration from environment variables."""
+        # Load council models
+        models_env = os.environ.get(ENV_COUNCIL_MODELS)
+        if models_env:
+            self._models = [m.strip() for m in models_env.split(",") if m.strip()]
+
+        # Load model pack overrides
+        pack_env_map = {
+            ModelPack.FAST: ENV_MODEL_FAST,
+            ModelPack.REASONING: ENV_MODEL_REASONING,
+            ModelPack.CODE: ENV_MODEL_CODE,
+            ModelPack.CRITIC: ENV_MODEL_CRITIC,
+        }
+        for pack, env_var in pack_env_map.items():
+            value = os.environ.get(env_var)
+            if value:
+                self._pack_overrides[pack] = value.strip()
+
+    def get_council_models(self) -> list[str]:
+        """Get the list of models for council runs.
+
+        Returns:
+            List of OpenRouter model IDs. If COUNCIL_MODELS env var is not set,
+            returns a single-element list with the default model.
+        """
+        if self._models:
+            return list(self._models)
+        # Return single default model if not configured
+        return [DEFAULT_MODEL_PACKS[ModelPack.DEFAULT]]
+
+    def get_model_for_pack(self, pack: ModelPack) -> str:
+        """Get the model for a specific pack.
+
+        Args:
+            pack: The model pack type.
+
+        Returns:
+            OpenRouter model ID for the pack.
+        """
+        # Check for override first
+        if pack in self._pack_overrides:
+            return self._pack_overrides[pack]
+        # Fall back to default
+        return DEFAULT_MODEL_PACKS.get(pack, DEFAULT_MODEL_PACKS[ModelPack.DEFAULT])
+
+    def is_multi_model_enabled(self) -> bool:
+        """Check if multi-model council is enabled.
+
+        Returns:
+            True if COUNCIL_MODELS is set with multiple models.
+        """
+        return self._models is not None and len(self._models) > 1
+
+
+def get_council_models() -> list[str]:
+    """Get the list of models for council runs.
+
+    Convenience function that uses the singleton ModelConfig.
+
+    Returns:
+        List of OpenRouter model IDs.
+    """
+    return ModelConfig.get_instance().get_council_models()
+
+
+def get_model_for_pack(pack: ModelPack) -> str:
+    """Get the model for a specific pack.
+
+    Convenience function that uses the singleton ModelConfig.
+
+    Args:
+        pack: The model pack type.
+
+    Returns:
+        OpenRouter model ID for the pack.
+    """
+    return ModelConfig.get_instance().get_model_for_pack(pack)
+
+
+def is_multi_model_enabled() -> bool:
+    """Check if multi-model council is enabled.
+
+    Convenience function that uses the singleton ModelConfig.
+
+    Returns:
+        True if COUNCIL_MODELS is set with multiple models.
+    """
+    return ModelConfig.get_instance().is_multi_model_enabled()
+
+
+def parse_models_string(models_str: str) -> list[str]:
+    """Parse a comma-separated string of model names.
+
+    Args:
+        models_str: Comma-separated model names.
+
+    Returns:
+        List of model names, trimmed and filtered.
+    """
+    return [m.strip() for m in models_str.split(",") if m.strip()]

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -49,6 +49,7 @@ class Council:
             enable_artifacts=config.enable_artifact_store if config else True,
             enable_health_check=config.enable_health_check if config else False,
             enable_graceful_degradation=config.enable_graceful_degradation if config else True,
+            models=config.models if config else None,
         )
 
         self.config = config or CouncilConfig(providers=self._providers)

--- a/src/llm_council/protocol/types.py
+++ b/src/llm_council/protocol/types.py
@@ -32,6 +32,14 @@ class CouncilConfig(BaseModel):
         default=["openrouter"],
         description="List of provider names to use for drafts",
     )
+    models: list[str] | None = Field(
+        default=None,
+        description=(
+            "List of OpenRouter model IDs for multi-model council. "
+            "When set with providers=['openrouter'], creates virtual providers for each model. "
+            "Example: ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o', 'google/gemini-pro']"
+        ),
+    )
     timeout: int = Field(
         default=120,
         ge=10,

--- a/src/llm_council/providers/openrouter.py
+++ b/src/llm_council/providers/openrouter.py
@@ -307,6 +307,25 @@ class OpenRouterProvider(ProviderAdapter):
             )
 
 
+def create_openrouter_for_model(model: str) -> OpenRouterProvider:
+    """Create an OpenRouter provider instance configured for a specific model.
+
+    This factory function is used to create multiple provider instances
+    for multi-model council runs.
+
+    Args:
+        model: OpenRouter model ID (e.g., "anthropic/claude-3.5-sonnet").
+
+    Returns:
+        Configured OpenRouterProvider instance.
+
+    Example:
+        >>> provider = create_openrouter_for_model("openai/gpt-4o")
+        >>> # This provider will always use gpt-4o for requests
+    """
+    return OpenRouterProvider(default_model=model)
+
+
 # Register the provider
 def _register() -> None:
     """Register the OpenRouter provider with the global registry."""

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -1,0 +1,255 @@
+"""Tests for multi-model council functionality."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm_council.config.models import (
+    DEFAULT_COUNCIL_MODELS,
+    DEFAULT_MODEL_PACKS,
+    ModelConfig,
+    ModelPack,
+    get_council_models,
+    get_model_for_pack,
+    is_multi_model_enabled,
+    parse_models_string,
+)
+from llm_council.providers.openrouter import OpenRouterProvider, create_openrouter_for_model
+
+
+class TestModelConfig:
+    """Tests for ModelConfig class."""
+
+    def setup_method(self) -> None:
+        """Reset singleton before each test."""
+        ModelConfig.reset()
+
+    def teardown_method(self) -> None:
+        """Clean up env vars after each test."""
+        ModelConfig.reset()
+        for key in [
+            "COUNCIL_MODELS",
+            "COUNCIL_MODEL_FAST",
+            "COUNCIL_MODEL_REASONING",
+            "COUNCIL_MODEL_CODE",
+            "COUNCIL_MODEL_CRITIC",
+        ]:
+            os.environ.pop(key, None)
+
+    def test_default_models_single(self) -> None:
+        """Without COUNCIL_MODELS env, returns single default model."""
+        models = get_council_models()
+        assert len(models) == 1
+        assert models[0] == DEFAULT_MODEL_PACKS[ModelPack.DEFAULT]
+
+    def test_multi_model_from_env(self) -> None:
+        """COUNCIL_MODELS env var enables multi-model."""
+        os.environ["COUNCIL_MODELS"] = "anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-pro"
+        ModelConfig.reset()
+
+        models = get_council_models()
+        assert len(models) == 3
+        assert "anthropic/claude-3.5-sonnet" in models
+        assert "openai/gpt-4o" in models
+        assert "google/gemini-pro" in models
+
+    def test_is_multi_model_enabled(self) -> None:
+        """is_multi_model_enabled returns correct value."""
+        assert not is_multi_model_enabled()
+
+        os.environ["COUNCIL_MODELS"] = "model1,model2"
+        ModelConfig.reset()
+        assert is_multi_model_enabled()
+
+    def test_single_model_not_multi(self) -> None:
+        """Single model in COUNCIL_MODELS is not multi-model."""
+        os.environ["COUNCIL_MODELS"] = "anthropic/claude-3.5-sonnet"
+        ModelConfig.reset()
+
+        assert not is_multi_model_enabled()
+        models = get_council_models()
+        assert len(models) == 1
+
+    def test_model_pack_defaults(self) -> None:
+        """Model packs have correct defaults."""
+        assert get_model_for_pack(ModelPack.FAST) == "anthropic/claude-3-haiku"
+        assert get_model_for_pack(ModelPack.REASONING) == "anthropic/claude-3-opus"
+        assert get_model_for_pack(ModelPack.CODE) == "openai/gpt-4o"
+        assert get_model_for_pack(ModelPack.CRITIC) == "anthropic/claude-3.5-sonnet"
+
+    def test_model_pack_overrides(self) -> None:
+        """Model pack env vars override defaults."""
+        os.environ["COUNCIL_MODEL_FAST"] = "custom/fast-model"
+        os.environ["COUNCIL_MODEL_CODE"] = "custom/code-model"
+        ModelConfig.reset()
+
+        assert get_model_for_pack(ModelPack.FAST) == "custom/fast-model"
+        assert get_model_for_pack(ModelPack.CODE) == "custom/code-model"
+        # Non-overridden packs still use defaults
+        assert get_model_for_pack(ModelPack.REASONING) == "anthropic/claude-3-opus"
+
+    def test_parse_models_string(self) -> None:
+        """parse_models_string correctly parses comma-separated models."""
+        result = parse_models_string("model1, model2, model3")
+        assert result == ["model1", "model2", "model3"]
+
+        result = parse_models_string("model1,model2")
+        assert result == ["model1", "model2"]
+
+        result = parse_models_string("  model1  ")
+        assert result == ["model1"]
+
+        result = parse_models_string("")
+        assert result == []
+
+    def test_models_with_whitespace(self) -> None:
+        """Models are trimmed of whitespace."""
+        os.environ["COUNCIL_MODELS"] = "  model1  ,  model2  "
+        ModelConfig.reset()
+
+        models = get_council_models()
+        assert models == ["model1", "model2"]
+
+
+class TestOpenRouterFactory:
+    """Tests for OpenRouter provider factory function."""
+
+    def test_create_openrouter_for_model(self) -> None:
+        """Factory creates provider with specified model."""
+        provider = create_openrouter_for_model("openai/gpt-4o")
+        assert isinstance(provider, OpenRouterProvider)
+        assert provider._default_model == "openai/gpt-4o"
+
+    def test_different_models_different_providers(self) -> None:
+        """Different models create distinct provider instances."""
+        provider1 = create_openrouter_for_model("anthropic/claude-3.5-sonnet")
+        provider2 = create_openrouter_for_model("openai/gpt-4o")
+
+        assert provider1 is not provider2
+        assert provider1._default_model == "anthropic/claude-3.5-sonnet"
+        assert provider2._default_model == "openai/gpt-4o"
+
+
+class TestOrchestratorMultiModel:
+    """Tests for orchestrator multi-model functionality."""
+
+    def setup_method(self) -> None:
+        """Reset model config before each test."""
+        ModelConfig.reset()
+
+    def teardown_method(self) -> None:
+        """Clean up after each test."""
+        ModelConfig.reset()
+        os.environ.pop("COUNCIL_MODELS", None)
+
+    def test_orchestrator_creates_virtual_providers(self) -> None:
+        """Orchestrator creates virtual providers when models configured."""
+        from llm_council.engine.orchestrator import Orchestrator, OrchestratorConfig
+
+        config = OrchestratorConfig(
+            models=["anthropic/claude-3.5-sonnet", "openai/gpt-4o", "google/gemini-pro"]
+        )
+        orchestrator = Orchestrator(providers=["openrouter"], config=config)
+
+        # Should have 3 providers (one per model)
+        assert len(orchestrator._providers) == 3
+        assert "anthropic/claude-3.5-sonnet" in orchestrator._providers
+        assert "openai/gpt-4o" in orchestrator._providers
+        assert "google/gemini-pro" in orchestrator._providers
+
+    def test_orchestrator_uses_env_models(self) -> None:
+        """Orchestrator uses COUNCIL_MODELS env var."""
+        os.environ["COUNCIL_MODELS"] = "model1,model2"
+        ModelConfig.reset()
+
+        from llm_council.engine.orchestrator import Orchestrator, OrchestratorConfig
+
+        config = OrchestratorConfig()
+        orchestrator = Orchestrator(providers=["openrouter"], config=config)
+
+        assert len(orchestrator._providers) == 2
+        assert "model1" in orchestrator._providers
+        assert "model2" in orchestrator._providers
+
+    def test_orchestrator_config_models_override_env(self) -> None:
+        """Config models take precedence over env var."""
+        os.environ["COUNCIL_MODELS"] = "env-model1,env-model2"
+        ModelConfig.reset()
+
+        from llm_council.engine.orchestrator import Orchestrator, OrchestratorConfig
+
+        config = OrchestratorConfig(models=["config-model1", "config-model2", "config-model3"])
+        orchestrator = Orchestrator(providers=["openrouter"], config=config)
+
+        # Should use config models, not env
+        assert len(orchestrator._providers) == 3
+        assert "config-model1" in orchestrator._providers
+        assert "env-model1" not in orchestrator._providers
+
+    def test_single_provider_no_multi_model(self) -> None:
+        """Single model does not trigger multi-model mode."""
+        from llm_council.engine.orchestrator import Orchestrator, OrchestratorConfig
+
+        config = OrchestratorConfig(models=["single-model"])
+        orchestrator = Orchestrator(providers=["openrouter"], config=config)
+
+        # Should fall back to standard provider initialization
+        # (single model doesn't trigger multi-model)
+        assert "openrouter" in orchestrator._providers
+
+    def test_non_openrouter_provider_no_multi_model(self) -> None:
+        """Multi-model only works with openrouter provider."""
+        from llm_council.engine.orchestrator import Orchestrator, OrchestratorConfig
+
+        config = OrchestratorConfig(models=["model1", "model2"])
+        # Using a different provider list
+        orchestrator = Orchestrator(providers=["anthropic"], config=config)
+
+        # Should not create virtual providers for non-openrouter
+        assert "anthropic" in orchestrator._providers or "anthropic" in orchestrator._provider_init_errors
+
+
+class TestCouncilMultiModel:
+    """Tests for Council class with multi-model configuration."""
+
+    def setup_method(self) -> None:
+        """Reset model config before each test."""
+        ModelConfig.reset()
+
+    def teardown_method(self) -> None:
+        """Clean up after each test."""
+        ModelConfig.reset()
+        os.environ.pop("COUNCIL_MODELS", None)
+
+    def test_council_with_models_config(self) -> None:
+        """Council accepts models in config."""
+        from llm_council import Council
+        from llm_council.protocol.types import CouncilConfig
+
+        config = CouncilConfig(
+            models=["anthropic/claude-3.5-sonnet", "openai/gpt-4o"]
+        )
+        council = Council(config=config)
+
+        # Verify the orchestrator was configured with models
+        assert council._orchestrator._config.models == ["anthropic/claude-3.5-sonnet", "openai/gpt-4o"]
+
+
+class TestDefaultCouncilModels:
+    """Tests for default council model configuration."""
+
+    def test_default_models_defined(self) -> None:
+        """DEFAULT_COUNCIL_MODELS contains expected models."""
+        assert len(DEFAULT_COUNCIL_MODELS) == 3
+        assert "anthropic/claude-3.5-sonnet" in DEFAULT_COUNCIL_MODELS
+        assert "openai/gpt-4o" in DEFAULT_COUNCIL_MODELS
+        assert "google/gemini-pro" in DEFAULT_COUNCIL_MODELS
+
+    def test_all_model_packs_defined(self) -> None:
+        """All ModelPack variants have default models."""
+        for pack in ModelPack:
+            assert pack in DEFAULT_MODEL_PACKS
+            assert DEFAULT_MODEL_PACKS[pack] is not None


### PR DESCRIPTION
## Summary

- **COUNCIL_MODELS** env var for comma-separated model list
- **--models** CLI flag for per-run model configuration  
- Virtual provider pattern for parallel drafts from different LLMs
- Model pack configuration (fast, reasoning, code, critic)
- 18 new tests for multi-model functionality

## Usage

```bash
# Via environment variable
export COUNCIL_MODELS="anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-pro"
council run router "task"

# Via CLI flag
council run router "task" --models "model1,model2,model3"
```

## Test plan

- [x] Unit tests for model configuration parsing
- [x] Unit tests for virtual provider creation
- [x] Integration tests with orchestrator
- [x] Manual test with real OpenRouter API (confirmed working)
- [x] All 138 tests passing

## Files changed

- `src/llm_council/config/` - New model configuration module
- `src/llm_council/engine/orchestrator.py` - Virtual provider creation
- `src/llm_council/cli/main.py` - --models flag
- `src/llm_council/protocol/types.py` - models in CouncilConfig
- `src/llm_council/providers/openrouter.py` - Factory function
- `tests/test_multi_model.py` - 18 new tests