### PR TITLE
fix(providers): handle None token counts in usage metadata

### DIFF
--- a/src/llm_council/providers/anthropic.py
+++ b/src/llm_council/providers/anthropic.py
@@ -318,11 +318,13 @@ class AnthropicProvider(ProviderAdapter):
                 )
 
         usage = None
-        if hasattr(response, "usage"):
+        if hasattr(response, "usage") and response.usage:
+            input_tokens = response.usage.input_tokens or 0
+            output_tokens = response.usage.output_tokens or 0
             usage = {
-                "prompt_tokens": response.usage.input_tokens,
-                "completion_tokens": response.usage.output_tokens,
-                "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+                "prompt_tokens": input_tokens,
+                "completion_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
             }
 
         return GenerateResponse(

--- a/src/llm_council/providers/google.py
+++ b/src/llm_council/providers/google.py
@@ -307,9 +307,9 @@ class GoogleProvider(ProviderAdapter):
         if hasattr(response, "usage_metadata") and response.usage_metadata:
             um = response.usage_metadata
             usage = {
-                "prompt_tokens": getattr(um, "prompt_token_count", 0),
-                "completion_tokens": getattr(um, "candidates_token_count", 0),
-                "total_tokens": getattr(um, "total_token_count", 0),
+                "prompt_tokens": getattr(um, "prompt_token_count", 0) or 0,
+                "completion_tokens": getattr(um, "candidates_token_count", 0) or 0,
+                "total_tokens": getattr(um, "total_token_count", 0) or 0,
             }
 
         finish_reason = None

--- a/src/llm_council/providers/openai.py
+++ b/src/llm_council/providers/openai.py
@@ -354,10 +354,13 @@ class OpenAIProvider(ProviderAdapter):
 
         usage = None
         if response.usage:
+            prompt_tokens = response.usage.prompt_tokens or 0
+            completion_tokens = response.usage.completion_tokens or 0
+            total_tokens = response.usage.total_tokens or 0
             usage = {
-                "prompt_tokens": response.usage.prompt_tokens,
-                "completion_tokens": response.usage.completion_tokens,
-                "total_tokens": response.usage.total_tokens,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
             }
 
         return GenerateResponse(

--- a/src/llm_council/providers/openrouter.py
+++ b/src/llm_council/providers/openrouter.py
@@ -318,9 +318,9 @@ class OpenRouterProvider(ProviderAdapter):
         usage_dict = None
         if usage:
             usage_dict = {
-                "prompt_tokens": usage.get("prompt_tokens", 0),
-                "completion_tokens": usage.get("completion_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
+                "prompt_tokens": usage.get("prompt_tokens", 0) or 0,
+                "completion_tokens": usage.get("completion_tokens", 0) or 0,
+                "total_tokens": usage.get("total_tokens", 0) or 0,
             }
 
         return GenerateResponse(

--- a/src/llm_council/providers/vertex.py
+++ b/src/llm_council/providers/vertex.py
@@ -483,11 +483,13 @@ class VertexAIProvider(ProviderAdapter):
                 )
 
         usage = None
-        if hasattr(response, "usage"):
+        if hasattr(response, "usage") and response.usage:
+            input_tokens = response.usage.input_tokens or 0
+            output_tokens = response.usage.output_tokens or 0
             usage = {
-                "prompt_tokens": response.usage.input_tokens,
-                "completion_tokens": response.usage.output_tokens,
-                "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+                "prompt_tokens": input_tokens,
+                "completion_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
             }
 
         return GenerateResponse(


### PR DESCRIPTION
## Summary

Fixes #22 - Google provider fails with validation error when `completion_tokens` is `None`.

- Added defensive `or 0` fallback to handle `None` token counts across all providers
- Prevents Pydantic validation errors when LLM APIs return `None` instead of `0`
- Applied consistent fix pattern to: google, vertex, anthropic, openai, openrouter

## Root Cause

Some LLM APIs (notably Gemini 3 Pro preview) return `None` for token counts in usage metadata. The `GenerateResponse.usage` field expects `Mapping[str, int]`, so `None` values fail Pydantic validation.

## Fix Details

| Provider | Fix Applied |
|----------|-------------|
| google.py | Added `or 0` to `getattr()` calls |
| vertex.py | Fixed Claude section (Gemini already had fix) |
| anthropic.py | Added `and response.usage` check + `or 0` fallback |
| openai.py | Added `or 0` fallback for all token fields |
| openrouter.py | Added `or 0` to `.get()` calls |

## Test plan

- [x] All 148 existing tests pass
- [x] Verified fix pattern matches vertex.py Gemini section (already working)