### PR TITLE
feat: ship mode-aware runtime and evaluation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ credentials.json
 
 # Specs (internal planning docs)
 specs/
+
+# Private local-only evaluation inputs and imported external repo material.
+# Use this for raw PR diffs, code snapshots, and benchmark fixtures sourced from
+# internal repos or external systems. Never commit its contents.
+.council-private/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-03-27
+
+### Added
+- Mode-aware runtime wiring across `Council` and `Orchestrator`
+  - runtime `mode`, `runtime_profile`, `reasoning_profile`, `temperature`, `max_tokens`, and output-schema overrides now flow into execution
+  - execution plans now expose effective mode, schema, model pack, providers, phase budgets, and degradation details
+- Routed handoff support
+  - `council run router ... --route` can now continue into the router-selected subagent and mode
+  - routed runs can carry model-pack, execution-profile, budget-class, and capability recommendations into the follow-up run
+- Capability-aware execution baseline
+  - capability planning and execution-profile selection added to the runtime
+  - initial packs include `repo-analysis`, `docs-research`, `planning-assess`, `diff-review`, `security-code-audit`, and `red-team-recon`
+- Deterministic evaluation tooling
+  - new `council eval`, `council eval-compare`, and `council eval-import-pr` commands
+  - public runtime baseline dataset under `evals/runtime-baseline.yaml`
+- Deep doctor support
+  - `council doctor --deep` now distinguishes installed/configured providers from providers that can answer a trivial non-interactive prompt
+
+### Changed
+- Canonical CLI provider names are now `codex`, `gemini`, and `claude`, with legacy aliases preserved for compatibility
+- Public docs now describe the current runtime surface, local-only eval import boundary, and routed execution behavior
+- Bounded runtime request caps were recalibrated to better match real review workloads
+
+### Fixed
+- Explicit user-selected providers and configured models now take precedence over subagent defaults
+- Auto-fallback now stays limited to the default unhealthy path instead of overriding explicit user provider choices
+- CLI provider timeout settlement now kills the full subprocess tree instead of hanging on timed-out children
+- Gemini CLI approval-mode handling updated to current CLI behavior
+- OpenAI timeout and provider error reporting now preserve the underlying cause chain for easier diagnosis
+- Bounded review prompts are slimmer and no longer force schema-heavy draft/critique instructions
+
 ## [0.6.4] - 2026-03-26
 
 ### Added
@@ -454,7 +485,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic provider adapters
 - JSON schema validation for subagent outputs
 
-[Unreleased]: https://github.com/sherifkozman/the-llm-council/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/sherifkozman/the-llm-council/compare/v0.6.4...v0.7.0
+[0.6.4]: https://github.com/sherifkozman/the-llm-council/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/sherifkozman/the-llm-council/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/sherifkozman/the-llm-council/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/sherifkozman/the-llm-council/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/sherifkozman/the-llm-council/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/sherifkozman/the-llm-council/compare/v0.5.2...v0.5.3

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ $ council run architect "Design a mass hallucination prevention system"
 
 A Multi-LLM Council Framework that orchestrates multiple LLM backends to enable **adversarial debate**, **cross-validation**, and **structured decision-making**.
 
+This release also includes a mode-aware execution path with runtime profiles,
+routed handoff, capability planning, and deterministic eval tooling. Those
+capabilities materially extend the package runtime, but they should not yet be
+treated as a claim of stable benchmarked superiority for review or security
+analysis.
+
 ## Why Use a Council?
 
 Single-model outputs have blind spots. By running multiple models in parallel and having them critique each other, the council:
@@ -72,13 +78,15 @@ Single-model outputs have blind spots. By running multiple models in parallel an
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-Model Council** | Run Claude, GPT-4, and Gemini in parallel via single OpenRouter key |
+| **Multi-Model Council** | Run Claude, GPT-5.4, and Gemini in parallel via OpenRouter or direct APIs |
+| **Mode-Aware Runtime** | `drafter`, `critic`, and `planner` honor runtime modes and execution profiles |
 | **Adversarial Critique** | Built-in critique phase identifies weaknesses and blind spots |
 | **Schema Validation** | JSON schema validation with automatic retry for structured outputs |
 | **Provider Agnostic** | Swap between OpenRouter, direct APIs, or CLI-based providers |
-| **Health Checks** | Preflight provider health checks with latency tracking |
+| **Deep Doctor** | `council doctor --deep` checks real non-interactive generation readiness |
 | **Graceful Degradation** | Automatic retry, fallback, and skip strategies for failures |
 | **Artifact Store** | Persistent storage of drafts with tiered summarization |
+| **Eval Tooling** | `eval`, `eval-compare`, and local-only `eval-import-pr` support reproducible checks |
 | **Secret-Safe Logging** | Redaction pipeline prevents credential leakage |
 
 ## Requirements
@@ -163,7 +171,7 @@ Copy the `skills/council/` directory to your agent's skills folder. The skill fo
 # Set your API key
 export OPENROUTER_API_KEY="your-key"
 
-# Run a council task (v0.5.0 syntax with modes)
+# Run a council task (v0.7.x syntax with modes)
 council run drafter --mode impl "Build a login page with OAuth"
 
 # Multi-model council (Claude + GPT-5 + Gemini debating)
@@ -176,6 +184,14 @@ council run drafter "Build a login page"
 
 # Code review with security analysis
 council run critic --mode review "Review auth changes" --verbose
+
+# Ask the router to choose the next subagent/mode, then follow through
+council run router "Assess whether we should add a hosted vector store" --route
+
+# Bound latency/cost for review-style runs
+council run critic --mode review "Review auth changes" \
+  --runtime-profile bounded \
+  --reasoning-profile off
 
 # Disable artifact storage for faster runs
 council run drafter "Quick fix" --no-artifacts
@@ -207,7 +223,31 @@ print(result.output)
 
 ```bash
 council doctor
+
+# Verify actual non-interactive generation readiness
+# May incur API/CLI usage.
+council doctor --deep --provider claude --provider gemini --provider codex
 ```
+
+### Run Deterministic Evals
+
+```bash
+# Public deterministic runtime checks
+council eval evals/runtime-baseline.yaml --providers openrouter
+
+# Compare named variants on the same dataset
+council eval-compare evals/runtime-baseline.yaml variants.yaml --providers openai
+```
+
+For private benchmark creation, import external PR review material into
+`.council-private/` only:
+
+```bash
+council eval-import-pr owner/repo 123
+```
+
+That path is gitignored and intended for local-only evaluation inputs. Do not
+commit imported diffs, copied code, or review fixtures into tracked repo paths.
 
 ## Architecture
 
@@ -266,7 +306,7 @@ council doctor
    └── Store drafts and outputs for context management
 ```
 
-## Subagents (v0.5.0)
+## Subagents (v0.7.x)
 
 ### Core Agents
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,18 +4,19 @@
 
 This document outlines the development direction for The LLM Council. We welcome community input on priorities and feature design.
 
-## Current Release: v0.4.13
+## Current Release: v0.7.0
 
-The foundation is complete:
+The current release foundation includes:
 
-- **Multi-model council** - Parallel drafts from Claude, GPT-4, Gemini via OpenRouter or direct APIs
+- **Multi-model council** - Parallel drafts from Claude, GPT-5.4, and Gemini via OpenRouter or direct APIs
 - **Adversarial critique** - Models challenge each other's outputs
 - **Validated synthesis** - JSON schema validation with retry logic
-- **10 specialized subagents** - router, planner, assessor, researcher, architect, implementer, reviewer, test-designer, shipper, red-team
+- **Mode-aware subagents** - primary runtime surface is `router`, `planner`, `researcher`, `drafter`, `critic`, and `synthesizer`, with legacy aliases still supported
 - **Graceful degradation** - Continues if some providers fail
 - **Provider flexibility** - OpenRouter, direct APIs (Anthropic, OpenAI, Google), Vertex AI (Gemini + Claude)
-- **CLI tooling** - `council run`, `council doctor`, `council config`
+- **CLI tooling** - `council run`, `council doctor`, `council eval`, `council eval-compare`, `council eval-import-pr`, `council config`
 - **Extended reasoning** - Support for thinking/reasoning modes (Anthropic, Google, OpenAI)
+- **Runtime controls** - `runtime_profile`, `reasoning_profile`, routed handoff, and deeper provider readiness checks
 - **Artifact store** - Content-addressed storage with tiered summarization
 
 ---
@@ -58,7 +59,38 @@ Route simpler tasks to cheaper models, escalate to stronger models on validation
 - Validator-driven escalation
 - Target: 20-50% cost reduction without quality loss
 
-**Why**: Not every task needs GPT-4. Smart routing reduces costs significantly.
+**Why**: Not every task needs the most expensive reasoning models. Smart
+routing reduces costs significantly.
+
+---
+
+### Mode-Native Capability Packs + Staged Execution
+
+**Priority: High** · `in progress`
+
+Move council from prompt-only execution toward mode-aware, lazy-loaded
+capabilities selected at runtime.
+
+- Keep `prompt_only` as the default for low-risk tasks
+- Add execution profiles such as `light_tools`, `grounded`, and `deep_analysis`
+- Load capability packs only when the mode and risk justify them
+- Prioritize `planner --mode plan|assess` and `critic --mode security` in the first rollout
+- Measure value per mode instead of relying on one blended quality metric
+
+Implemented baseline in the current release line:
+
+- mode-aware runtime selection is wired through `Council` and `Orchestrator`
+- routed handoff can follow the router-selected subagent/mode
+- capability planning is exposed in execution plans
+- deterministic eval tooling is public
+- private PR-import benchmarking remains local-only under `.council-private/`
+
+Reference design:
+- `docs/architecture/capability-augmented-council.md`
+
+**Why**: Prompts alone are not enough for planning, security, research, and
+code-aware tasks. Mode-native evidence gathering should improve output quality
+without forcing every run into an expensive agent loop.
 
 ---
 
@@ -176,4 +208,4 @@ Have an idea not listed here? [Open an issue](https://github.com/sherifkozman/th
 
 ---
 
-*Last updated: 2025-12-23*
+*Last updated: 2026-03-27*

--- a/config/tool_registry.yaml
+++ b/config/tool_registry.yaml
@@ -21,7 +21,7 @@ tools:
         type: integer
         default: 5
         description: Maximum results to return
-    roles: [drafter, researcher]
+    roles: [drafter, researcher, planner, critic]
 
   context7_lookup:
     name: context7_lookup
@@ -35,7 +35,7 @@ tools:
         type: string
         required: false
         description: Specific topic to focus on
-    roles: [drafter, researcher]
+    roles: [drafter, researcher, planner]
 
   # Code analysis tools
   code_analysis:
@@ -63,8 +63,8 @@ tools:
       path:
         type: string
         required: false
-        description: Path to search in (default: current directory)
-    roles: [drafter, critic, researcher]
+        description: "Path to search in (default: current directory)"
+    roles: [drafter, critic, researcher, planner]
 
   # File operations
   read_file:
@@ -95,3 +95,67 @@ tools:
         required: true
         description: List of checklist items
     roles: [planner, synthesizer]
+
+capability_packs:
+  repo-analysis:
+    name: repo-analysis
+    description: Repository-aware context gathering for implementation, review, and planning
+    tools: [read_file, grep_search, code_analysis]
+    roles: [drafter, critic, planner]
+    evidence_requirements:
+      - Verify claims against local repository context where possible
+      - Name missing repository context explicitly when evidence is incomplete
+
+  docs-research:
+    name: docs-research
+    description: Documentation and current-information grounding
+    tools: [web_search, context7_lookup]
+    roles: [drafter, researcher, planner, critic]
+    evidence_requirements:
+      - Prefer authoritative or official documentation
+      - State freshness or source confidence when external information may change
+
+  planning-assess:
+    name: planning-assess
+    description: Planning and decision-support toolkit for plans and assessments
+    tools: [create_checklist, read_file, grep_search]
+    roles: [planner]
+    evidence_requirements:
+      - Identify dependencies, blockers, and alternatives explicitly
+      - Distinguish verified constraints from assumptions
+
+  security-audit:
+    name: security-audit
+    description: Deprecated compatibility alias for security code-audit support
+    tools: [code_analysis, grep_search, read_file, web_search]
+    roles: [critic]
+    evidence_requirements:
+      - Ground findings in realistic attack paths and affected components
+      - Separate confirmed weaknesses from speculative concerns
+
+  security-code-audit:
+    name: security-code-audit
+    description: Code-centric security review support for vulnerable flows and dangerous patterns
+    tools: [code_analysis, grep_search, read_file]
+    roles: [critic]
+    evidence_requirements:
+      - Tie weaknesses to concrete files, flows, or security-sensitive operations
+      - Separate code-level verification from speculative attack narrative
+
+  red-team-recon:
+    name: red-team-recon
+    description: Attack-surface and threat-model reconnaissance support
+    tools: [grep_search, read_file, web_search]
+    roles: [critic]
+    evidence_requirements:
+      - Identify exposed surfaces, trust boundaries, and attacker prerequisites explicitly
+      - Distinguish observed exposure from inferred exploitation paths
+
+  diff-review:
+    name: diff-review
+    description: Code review support focused on changed code and local impact
+    tools: [read_file, grep_search, code_analysis]
+    roles: [critic]
+    evidence_requirements:
+      - Tie review findings to concrete locations or behavioral impact
+      - Avoid preference-only commentary unless it affects maintainability or risk

--- a/docs/architecture/capability-augmented-council.md
+++ b/docs/architecture/capability-augmented-council.md
@@ -1,0 +1,437 @@
+# Capability-Augmented Council
+
+**Status:** In progress
+**Last updated:** 2026-03-27
+
+## Summary
+
+LLM Council should evolve from a prompt-centric multi-model pipeline into a
+mode-aware execution system that loads evidence-gathering capabilities only
+when the task requires them.
+
+The goal is not to turn council into a generic agent runtime. The goal is to
+make each supported mode materially better at its own job while preserving
+predictable cost and latency.
+
+This spec includes planning and security modes as first-class targets, not
+just implementation and review.
+
+## Problem
+
+The repo already defines multiple modes and roles:
+
+- `drafter --mode impl|arch|test`
+- `critic --mode review|security`
+- `planner --mode plan|assess`
+- `researcher`, `router`, `synthesizer`
+
+The current runtime is still dominated by a generic three-phase flow:
+
+1. parallel drafts
+2. critique
+3. synthesis
+
+That is useful, but it leaves quality on the table because prompts alone are
+not enough for many tasks:
+
+- planning needs dependency and risk evidence
+- assessment needs explicit decision criteria and alternatives
+- security needs attack-surface and exploit-path grounding
+- implementation needs codebase context
+- research needs current sources and citations
+
+The repo already points toward a better architecture:
+
+- router output can include `mode`, `model_pack`, and `suggested_tools`
+- the tool registry supports role-based capabilities
+- the skill package positions council as a reusable agent skill
+
+The missing piece is runtime execution that actually consumes those signals.
+
+## Grounded Observations
+
+This document started as a kickoff spec. The current release line now has a partial
+implementation of the design, so these observations describe the remaining gap,
+not a blank-slate system.
+
+- `CouncilConfig` now propagates `mode`, `temperature`, `max_tokens`,
+  `runtime_profile`, `reasoning_profile`, and `output_schema` into runtime
+  execution.
+- Consolidated subagent YAML files declare mode-specific schema, prompts,
+  reasoning, model packs, and in some cases provider/model preferences.
+- Router output can now drive routed follow-up runs, model-pack selection, and
+  capability planning metadata.
+- `ToolRegistry` and `config/tool_registry.yaml` now participate in capability
+  pack selection, but the evidence/execution depth is still incomplete for some
+  modes.
+
+This means the package has moved beyond prompt-only wiring, but mode-native
+quality and benchmark maturity are still incomplete.
+
+## Goals
+
+- Make mode-specific configuration executable rather than descriptive.
+- Keep prompt-only execution as the default for low-risk, low-context tasks.
+- Add lazy-loaded capability packs for tasks that need evidence.
+- Measure quality and cost per mode instead of using one blended metric.
+- Prioritize planning and security alongside implementation and review.
+
+## Non-Goals
+
+- Building a general plugin marketplace in the first phase.
+- Loading every tool on every run.
+- Replacing the debate/critique/synthesis model with a fully autonomous agent loop.
+- Claiming quality gains without mode-specific evaluation.
+
+## Design Principles
+
+### 1. Mode First
+
+The execution engine should optimize for the current mode, not for a generic
+"best prompt".
+
+### 2. Evidence Before Confidence
+
+Modes that make claims about code, risks, plans, or external facts should
+gather evidence before producing high-confidence output.
+
+### 3. Lazy Capabilities
+
+Prompt-only should remain available and cheap. Tooling and skills should be
+loaded only when routing or validation indicates they are needed.
+
+### 4. Measured Tradeoffs
+
+Every added capability must justify itself in quality, precision, acceptance,
+or speed. No decorative complexity.
+
+## Target Architecture
+
+### Execution Profiles
+
+Add an explicit execution profile selected by routing and/or runtime policy:
+
+- `prompt_only`
+- `light_tools`
+- `grounded`
+- `deep_analysis`
+
+The router should recommend a profile. The orchestrator may escalate if the
+task is high-risk or the first pass lacks required evidence.
+
+### Capability Packs
+
+Capability packs are internal bundles of tools, prompts, and evidence rules.
+They are not user-facing plugins in phase 1.
+
+Initial packs:
+
+- `repo-analysis`
+- `docs-research`
+- `planning-assess`
+- `security-code-audit`
+- `red-team-recon`
+- `diff-review`
+
+### Staged Execution
+
+Replace the flat "always draft, critique, synthesize" mental model with a
+staged model:
+
+1. route the task
+2. select mode + execution profile + capability pack
+3. gather evidence if required
+4. run drafts against the evidence-backed context
+5. critique the drafts
+6. synthesize the final output
+7. validate schema and evidence requirements
+
+## Mode-to-Capability Map
+
+| Subagent / Mode | Primary capability packs | Why |
+|---|---|---|
+| `planner --mode plan` | `planning-assess`, `repo-analysis` | plans need dependencies, risks, owners, and deliverables grounded in repo reality |
+| `planner --mode assess` | `planning-assess`, `docs-research` | decisions need criteria, alternatives, reversibility, and external/vendor context |
+| `critic --mode security` | `red-team-recon`, `security-code-audit`, `repo-analysis` | security needs distinct attack-surface recon and code-level weakness evidence before synthesizing a red-team assessment |
+| `critic --mode review` | `diff-review`, `repo-analysis` | review quality improves with changed-hunk context, symbol context, and test impact |
+| `researcher` | `docs-research` | research needs citations, freshness, and source ranking |
+| `drafter --mode impl` | `repo-analysis`, optional `docs-research` | implementation should follow local patterns and current APIs |
+| `drafter --mode arch` | `repo-analysis` | architecture needs interfaces, boundaries, and dependency awareness |
+| `drafter --mode test` | `repo-analysis` | test design needs code-under-test discovery and gap analysis |
+| `synthesizer` | no primary pack; consumes evidence | synthesis should merge grounded outputs rather than gather new evidence by default |
+
+## Capability Pack Scope
+
+### `repo-analysis`
+
+Suggested initial tools:
+
+- `read_file`
+- `grep_search`
+- code inventory / symbol summary
+- dependency map
+- changed-files summarizer
+
+Target consumers:
+
+- `drafter`
+- `critic`
+- `planner`
+
+### `docs-research`
+
+Suggested initial tools:
+
+- `web_search`
+- `context7_lookup`
+- source ranking
+- citation extraction
+
+Target consumers:
+
+- `researcher`
+- `planner --mode assess`
+- `drafter --mode impl` when external APIs are involved
+
+### `planning-assess`
+
+Suggested initial tools:
+
+- checklist generation
+- dependency/risk matrix generation
+- alternative comparison helper
+- effort/reversibility template builder
+
+Target consumers:
+
+- `planner --mode plan`
+- `planner --mode assess`
+
+### `security-code-audit`
+
+Suggested initial tools:
+
+- auth/dataflow grep patterns
+- secret/config misuse checks
+- dependency advisory lookup
+- code-path and sink/source evidence
+
+Target consumers:
+
+- `critic --mode security`
+
+### `red-team-recon`
+
+Suggested initial tools:
+
+- attack-surface inventory
+- exposed-route and callback discovery
+- trust-boundary and entry-point hints
+- attacker-prerequisite framing
+
+Target consumers:
+
+- `critic --mode security`
+
+### `diff-review`
+
+Suggested initial tools:
+
+- git diff parser
+- hunk-to-file mapper
+- nearby context fetcher
+- test impact summarizer
+
+Target consumers:
+
+- `critic --mode review`
+
+## Phased Rollout
+
+### P0: Runtime Truthfulness
+
+Objective: make declared mode behavior real.
+
+Deliverables:
+
+- propagate `mode` through `Council` and `Orchestrator`
+- apply mode-specific schema selection
+- apply mode-specific prompt extensions
+- apply mode-specific model pack and model selection
+- apply mode-specific provider preferences where supported
+- surface the effective execution plan in `--dry-run` and `--verbose`
+- add tests proving mode-specific behavior is honored
+
+Primary files:
+
+- `src/llm_council/council.py`
+- `src/llm_council/engine/orchestrator.py`
+- `src/llm_council/subagents/__init__.py`
+- `src/llm_council/cli/main.py`
+
+Success metrics:
+
+- 100% mode/schema selection correctness in integration tests
+- 100% mode/prompt selection correctness in integration tests
+- zero CLI flags accepted but silently ignored for supported mode/runtime settings
+
+### P1: Capability Selection
+
+Objective: enable lazy-loaded evidence gathering.
+
+Deliverables:
+
+- define execution profiles
+- extend router output consumption in runtime
+- load role-appropriate capability packs from tool registry
+- support prompt-only fallback for low-risk tasks
+
+Primary files:
+
+- `src/llm_council/engine/orchestrator.py`
+- `src/llm_council/registry/tool_registry.py`
+- `config/tool_registry.yaml`
+- `src/llm_council/subagents/router.yaml`
+- `src/llm_council/schemas/router.json`
+
+Success metrics:
+
+- prompt-only remains default for low-risk tasks
+- capability packs activate only when requested or justified
+- tool activation telemetry available per run
+
+### P1.5: Planning and Security Hardening
+
+Objective: improve the two high-value, under-grounded modes first.
+
+Deliverables:
+
+- `planning-assess` capability pack
+- `security-code-audit` and `red-team-recon` capability packs
+- evidence requirements for planning and security outputs
+- mode-specific validation rules for unsupported claims
+
+Success metrics:
+
+- lower unsupported-claim rate in planning outputs
+- higher confirmed-finding rate in security outputs
+- lower recommendation reversal rate in assess mode
+
+### P2: Mode-Specific Evaluation
+
+Objective: measure value honestly.
+
+Deliverables:
+
+- benchmark sets for `plan`, `assess`, `security`, `review`, `impl`, `arch`, `test`, `research`
+- per-mode scorecards
+- cost/latency tracking by mode and execution profile
+
+Success metrics:
+
+- every mode has at least one benchmark set and a documented scorecard
+- regressions are caught before release
+
+### P3: Feedback and Iteration
+
+Objective: close the loop after first adoption.
+
+Deliverables:
+
+- acceptance / dismissal capture for findings and recommendations
+- repeated false-positive tracking
+- capability-pack tuning based on observed value
+
+Success metrics:
+
+- measurable drop in repeated low-value outputs
+- measurable increase in accepted outcomes per cost dollar
+
+## Per-Mode Scorecards
+
+### Planning (`planner --mode plan`)
+
+- plan acceptance rate
+- missed dependency rate
+- missed risk rate
+- number of follow-up clarifications needed
+
+### Assessment (`planner --mode assess`)
+
+- recommendation reversal rate
+- alternatives coverage
+- reversibility coverage
+- confidence calibration against later outcomes
+
+### Security (`critic --mode security`)
+
+- confirmed finding rate
+- invalid exploit-path rate
+- severity calibration accuracy
+- remediation usefulness score
+
+### Review (`critic --mode review`)
+
+- accepted finding rate
+- invalid location/snippet rate
+- false-positive rate
+- cost per accepted finding
+
+### Research (`researcher`)
+
+- citation validity rate
+- freshness success rate
+- unsupported claim rate
+
+### Implementation (`drafter --mode impl`)
+
+- first-pass build/test success
+- human rework after generation
+- local-pattern adherence
+
+### Architecture (`drafter --mode arch`)
+
+- constraint miss rate
+- interface completeness
+- major issue discovery before implementation
+
+### Test (`drafter --mode test`)
+
+- defect-detection rate
+- coverage delta
+- maintenance burden of generated tests
+
+## Kickoff Task Breakdown
+
+1. Fix mode plumbing end to end.
+2. Extend router output schema with execution profile and required capabilities.
+3. Add runtime execution plan object and expose it in CLI output.
+4. Implement `planning-assess` capability pack.
+5. Implement `security-code-audit` and `red-team-recon` capability packs.
+6. Implement `docs-research` capability pack.
+7. Implement `repo-analysis` capability pack.
+8. Add per-mode eval harness and baseline datasets.
+
+## Recommended Order
+
+- Start with `planner --mode plan`, `planner --mode assess`, and `critic --mode security`.
+- Then lift `researcher`.
+- Then lift `drafter --mode impl|arch|test`.
+- Then refine `critic --mode review`.
+
+This order is intentional:
+
+- planning and assessment improve strategic value quickly
+- security is high-risk and benefits strongly from evidence
+- research unlocks other modes
+- implementation and review benefit from shared repo-analysis after that
+
+## Deferred Work
+
+- broad external plugin ecosystem
+- fully autonomous fixing loops
+- persistent cross-run memory for all modes
+- dynamic learning from arbitrary user chats
+
+These may be useful later, but they are not needed to prove the value of
+capability-augmented council.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,41 @@
 # LLM Council Documentation
 
-LLM Council is a Multi-LLM orchestration framework that enables adversarial debate, cross-validation, and structured decision-making across multiple language model providers.
+LLM Council is a multi-LLM orchestration framework for adversarial debate,
+cross-validation, and structured decision-making across multiple model
+providers.
+
+The public package now supports both:
+
+- the core three-phase council flow
+- a mode-aware execution path with lightweight capability
+  planning, routed handoff, and evaluation tooling
 
 ## Overview
 
-LLM Council orchestrates multiple LLM backends in a three-phase workflow:
+LLM Council centers on a three-phase workflow:
 
 1. **Parallel Drafts** - Multiple providers generate independent solutions concurrently
 2. **Adversarial Critique** - A critic model identifies weaknesses, contradictions, and blind spots
 3. **Synthesis** - The best elements are merged, critiques addressed, and output validated against JSON schemas
 
-This approach produces more robust, well-considered outputs than single-model generation.
+This approach is intended to produce more robust, better-audited outputs than a
+single-model pass. The newer capability-aware execution path should be treated
+as an evolving runtime surface rather than a claim of fully benchmarked review
+or security quality.
 
 ## Key Features
 
 ### Multi-Model Orchestration
-Run parallel drafts from Claude (Anthropic), GPT (OpenAI), Gemini (Google), or any supported provider. The framework automatically coordinates multiple API calls and merges results.
+Run parallel drafts from Claude (Anthropic), GPT-5.4 (OpenAI), Gemini
+(Google/Vertex), or any supported provider. The framework coordinates multiple
+provider calls and merges results into a structured output.
+
+### Mode-Aware Runtime
+Core subagents such as `drafter`, `critic`, and `planner` now honor explicit
+`--mode` selection at runtime instead of treating mode definitions as static
+YAML only. Execution profiles such as `prompt_only`,
+`light_tools`, `grounded`, and `deep_analysis` are exposed in the runtime and
+evaluation surfaces.
 
 ### Adversarial Critique
 Built-in critique phase systematically identifies:
@@ -25,14 +45,24 @@ Built-in critique phase systematically identifies:
 - Contradictory recommendations
 
 ### Schema Validation
-JSON Schema validation with automatic retry ensures structured outputs conform to expected formats. Failed validations trigger re-synthesis with error feedback.
+JSON Schema validation with automatic retry ensures structured outputs conform to expected formats. Failed validations trigger re-synthesis with validation error details.
 
 ### Provider Agnostic
 Swap between providers seamlessly:
 - **OpenRouter** - Single API key for 100+ models (recommended)
 - **Direct APIs** - Anthropic, OpenAI, Google native SDKs
-- **CLI Providers** - Codex CLI, Gemini CLI for local/offline use
+- **CLI Providers** - `codex`, `gemini`, and `claude` via local CLIs
 - **Custom Providers** - Plugin architecture via Python entry points
+
+### Deep Doctor
+`council doctor --deep` distinguishes “installed/configured” from “can answer a
+trivial non-interactive prompt right now.” This is useful for diagnosing local
+CLI providers and flaky auth or SDK setup.
+
+### Evaluation Tooling
+`council eval`, `council eval-compare`, and `council eval-import-pr` provide a
+public deterministic evaluation harness plus local-only PR-import support for
+private benchmark creation.
 
 ### IDE Integration
 JSON-lines protocol enables seamless integration with Claude Code and other IDEs. Results stream as structured JSON for programmatic consumption.
@@ -75,6 +105,18 @@ council run drafter --mode impl "Build a REST API for user authentication"
 # Check provider status
 council doctor
 
+# Verify actual non-interactive generation readiness
+# May incur API/CLI usage.
+council doctor --deep --provider claude --provider gemini --provider codex
+
+# Router handoff: classify, then run the chosen subagent/mode
+council run router "Assess whether we should adopt a hosted vector store" --route
+
+# Bound cost and latency for a run
+council run critic --mode review "Review these auth changes" \
+  --runtime-profile bounded \
+  --reasoning-profile off
+
 # Get JSON output
 council run planner "Add dark mode support" --json
 ```
@@ -103,22 +145,26 @@ else:
 
 ## Subagents
 
-LLM Council includes 10 specialized subagents, each with tailored prompts and JSON schemas:
+LLM Council currently exposes six primary subagents, with several backwards
+compatible aliases still supported:
 
 | Subagent | Purpose | Output Schema |
 |----------|---------|---------------|
 | `router` | Classify and route tasks to appropriate subagents | Task classification with routing recommendation |
-| `planner` | Create execution roadmaps with phases and dependencies | Phased plan with milestones and risks |
-| `assessor` | Make build/buy/no-build decisions with weighted criteria | Decision matrix with scores and rationale |
-| `researcher` | Deep market and technical research with citations | Research findings with formal references |
-| `architect` | Design system architecture, APIs, data models | Architecture diagrams and specifications |
-| `implementer` | Generate production-ready code with tests | Code files with test coverage |
-| `reviewer` | Review code for bugs, security, style issues | Findings with CWE IDs and severity |
-| `test-designer` | Design comprehensive test suites | Test plan with coverage goals |
-| `shipper` | Generate release notes and deployment guides | Release documentation |
-| `red-team` | Security threat modeling and attack vectors | Threat model with mitigations |
+| `planner` | Create execution roadmaps and assessment outputs | Plans, phases, risks, decisions |
+| `researcher` | Research with citations and evidence | Research findings and references |
+| `drafter` | Implementation, architecture, and test design | Code/design/test outputs by mode |
+| `critic` | Code review and security analysis | Review or red-team findings by mode |
+| `synthesizer` | Final merge and structured output production | Final schema-conforming output |
 
-Each subagent enforces structured output via JSON Schema, ensuring consistent, parseable results.
+Primary runtime modes:
+
+- `drafter --mode impl|arch|test`
+- `critic --mode review|security`
+- `planner --mode plan|assess`
+
+Legacy aliases such as `implementer`, `architect`, `reviewer`, `red-team`,
+`assessor`, and `test-designer` still work for backwards compatibility.
 
 ## How It Works
 
@@ -126,31 +172,38 @@ Each subagent enforces structured output via JSON Schema, ensuring consistent, p
 USER TASK
     |
     v
+[ROUTE / MODE RESOLUTION]
+    |
+    +-- Optional router handoff
+    +-- Resolve mode, schema, model pack, providers
+    |
+    v
+[EVIDENCE SELECTION]
+    |
+    +-- prompt_only (default)
+    +-- or capability-backed execution
+    |
+    v
 [PARALLEL DRAFTS]
     |
-    +-- Provider A (e.g., Claude Opus)      --> Draft A
-    +-- Provider B (e.g., GPT-4)            --> Draft B
-    +-- Provider C (e.g., Gemini Pro)       --> Draft C
+    +-- Provider A --> Draft A
+    +-- Provider B --> Draft B
+    +-- Provider C --> Draft C
     |
     v
 [ADVERSARIAL CRITIQUE]
     |
-    +-- Critic Model analyzes all drafts
-    +-- Identifies weaknesses, contradictions, blind spots
+    +-- Challenge contradictions and weak assumptions
     |
     v
 [SYNTHESIS]
     |
-    +-- Merge best elements from drafts
-    +-- Address critique points
+    +-- Merge best elements
     +-- Validate against JSON Schema
-    +-- Retry on validation failure (max 3 attempts)
+    +-- Retry on validation failure
     |
     v
 [STRUCTURED OUTPUT]
-    |
-    +-- Success: JSON matching schema
-    +-- Failure: Validation errors + partial output
 ```
 
 ## Configuration
@@ -217,6 +270,8 @@ llm_council/
 
 ## Next Steps
 
+- [Capability-Augmented Council](architecture/capability-augmented-council.md) - Kickoff spec for mode-native capabilities, staged execution, and per-mode evaluation
+- [Eval Datasets](../evals/README.md) - Baseline datasets and usage for `council eval`
 - [OpenRouter Quickstart](quickstart/openrouter.md) - Recommended setup with single API key
 - [Direct APIs Quickstart](quickstart/direct-apis.md) - Using Anthropic, OpenAI, Google directly
 - [Creating Custom Providers](providers/creating-providers.md) - Build your own provider adapters

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,23 @@
+# Eval Datasets
+
+This directory contains baseline evaluation datasets for `council eval`.
+
+Current datasets:
+
+- `runtime-baseline.yaml`: checks mode-aware runtime behavior, capability
+  activation, and minimal structured outputs for the most important modes.
+
+Example:
+
+```bash
+council eval evals/runtime-baseline.yaml --providers openrouter
+```
+
+This harness is intentionally deterministic. It checks execution plans and
+required output structure first. It does not try to replace human judgment for
+semantic quality.
+
+For internal benchmark creation, keep any raw PR diffs, copied code, or review
+fixtures sourced from other repositories under `.council-private/`. That path is
+gitignored and intended for local-only evaluation inputs. Do not commit those
+materials into `evals/` or other tracked repo paths.

--- a/evals/runtime-baseline.yaml
+++ b/evals/runtime-baseline.yaml
@@ -1,0 +1,111 @@
+version: 1
+name: runtime-baseline
+description: >
+  Baseline dataset for mode-aware runtime behavior, capability activation,
+  and minimal structured outputs across high-value modes.
+cases:
+  - id: planner-plan-runtime
+    task: Plan the rollout for capability-augmented council in this repository
+    subagent: planner
+    mode: plan
+    expectations:
+      success: true
+      execution_plan_values:
+        mode: plan
+        execution_profile: light_tools
+        budget_class: normal
+      required_capabilities:
+        - planning-assess
+        - repo-analysis
+      executed_capabilities:
+        - planning-assess
+        - repo-analysis
+      minimum_evidence_items: 2
+      output_keys:
+        - objective
+        - phases
+        - success_criteria
+        - risks
+
+  - id: planner-assess-runtime
+    task: Assess whether llm-council should split security analysis into code audit and red-team recon
+    subagent: planner
+    mode: assess
+    expectations:
+      success: true
+      execution_plan_values:
+        mode: assess
+        execution_profile: grounded
+        budget_class: premium
+      required_capabilities:
+        - planning-assess
+        - docs-research
+      output_keys:
+        - decision
+        - criteria_evaluation
+        - recommendation
+        - reasoning
+
+  - id: critic-security-runtime
+    task: Find all the ways an attacker could exploit our auth system
+    subagent: critic
+    mode: security
+    expectations:
+      success: true
+      execution_plan_values:
+        mode: security
+        execution_profile: deep_analysis
+        budget_class: premium
+      required_capabilities:
+        - red-team-recon
+        - security-code-audit
+        - repo-analysis
+      executed_capabilities:
+        - red-team-recon
+        - security-code-audit
+        - repo-analysis
+      minimum_evidence_items: 3
+      output_keys:
+        - review_summary
+        - issues
+        - recommendations
+        - reasoning
+
+  - id: critic-review-runtime
+    task: Review the current branch changes for correctness risks
+    subagent: critic
+    mode: review
+    expectations:
+      success: true
+      execution_plan_values:
+        mode: review
+        execution_profile: light_tools
+        budget_class: normal
+      required_capabilities:
+        - diff-review
+        - repo-analysis
+      minimum_evidence_items: 1
+      output_keys:
+        - review_summary
+        - issues
+        - recommendations
+        - reasoning
+
+  - id: researcher-docs-runtime
+    task: Research React server component best practices
+    subagent: researcher
+    expectations:
+      success: true
+      execution_plan_values:
+        execution_profile: grounded
+        budget_class: normal
+      required_capabilities:
+        - docs-research
+      executed_capabilities:
+        - docs-research
+      minimum_evidence_items: 1
+      output_keys:
+        - research_question
+        - summary
+        - findings
+        - sources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "the-llm-council"
-version = "0.6.4"
+version = "0.7.0"
 description = "Multi-LLM Council Framework for adversarial debate, cross-validation, and structured decision-making"
 readme = "README.md"
 license = "MIT"

--- a/src/llm_council/__init__.py
+++ b/src/llm_council/__init__.py
@@ -20,7 +20,7 @@ try:
 
     __version__ = _pkg_version("the-llm-council")
 except Exception:
-    __version__ = "0.6.1"  # fallback
+    __version__ = "0.7.0"  # fallback
 
 __all__ = [
     "__version__",

--- a/src/llm_council/cli/main.py
+++ b/src/llm_council/cli/main.py
@@ -19,7 +19,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 import yaml
@@ -38,6 +38,9 @@ from llm_council.evaluation import (
     run_eval_dataset,
 )
 from llm_council.protocol.types import ReasoningProfile, RuntimeProfile
+
+if TYPE_CHECKING:
+    from llm_council.protocol.types import CouncilConfig
 
 # Global state for CLI context
 _cli_state: dict[str, Any] = {
@@ -189,7 +192,8 @@ def _load_config() -> dict[str, Any]:
 def _load_config_defaults() -> dict[str, Any]:
     """Load defaults section from config file."""
     config = _load_config()
-    return config.get("defaults", {})
+    defaults = config.get("defaults", {})
+    return defaults if isinstance(defaults, dict) else {}
 
 
 def _load_provider_configs() -> dict[str, dict[str, Any]]:
@@ -453,14 +457,14 @@ def run(
 
     # Handle dry-run
     if dry_run:
-        effective_schema = schema_file
-        if not effective_schema:
+        effective_schema: str = str(schema_file) if schema_file else "default"
+        if not schema_file:
             try:
                 from llm_council.subagents import get_effective_schema, load_subagent
 
-                effective_schema = get_effective_schema(
-                    load_subagent(resolved_agent), resolved_mode
-                ) or "default"
+                effective_schema = (
+                    get_effective_schema(load_subagent(resolved_agent), resolved_mode) or "default"
+                )
             except Exception:
                 effective_schema = "default"
 
@@ -529,22 +533,15 @@ def run(
             council.run(task=task_text, subagent=resolved_agent, follow_router=route)
         )
 
-        # Format output
-        if output_json:
-            output_text = json.dumps(result.model_dump(), indent=2, default=str)
-        else:
-            output_text = None
+        output_payload = json.dumps(result.model_dump(), indent=2, default=str)
 
         # Write to file or stdout
         if output_file:
             output_file.parent.mkdir(parents=True, exist_ok=True)
-            if output_json:
-                output_file.write_text(output_text)
-            else:
-                output_file.write_text(json.dumps(result.model_dump(), indent=2, default=str))
+            output_file.write_text(output_payload)
             _print(f"[green]Output written to {output_file}[/green]")
         elif output_json:
-            print(output_text)
+            print(output_payload)
         else:
             if result.success:
                 console.print(
@@ -612,9 +609,7 @@ def run(
                         )
                     pending_capabilities = result.execution_plan.get("pending_capabilities") or []
                     if pending_capabilities:
-                        console.print(
-                            "  Pending capabilities: " + ", ".join(pending_capabilities)
-                        )
+                        console.print("  Pending capabilities: " + ", ".join(pending_capabilities))
                     model_overrides = result.execution_plan.get("model_overrides") or {}
                     if model_overrides:
                         console.print(
@@ -633,27 +628,31 @@ def run(
                         console.print(
                             "  Phase token budgets: "
                             + ", ".join(
-                                f"{phase}={tokens}"
-                                for phase, tokens in phase_token_budgets.items()
+                                f"{phase}={tokens}" for phase, tokens in phase_token_budgets.items()
                             )
                         )
                     if reasoning:
                         console.print(
                             "  Reasoning: "
                             + ", ".join(
-                                f"{key}={value}" for key, value in reasoning.items() if value is not None
+                                f"{key}={value}"
+                                for key, value in reasoning.items()
+                                if value is not None
                             )
                         )
                 if result.routed and result.routing_decision:
+                    routing_mode = result.routing_decision.get("mode")
+                    routing_mode_suffix = (
+                        f" --mode {routing_mode}" if isinstance(routing_mode, str) else ""
+                    )
                     console.print("\n[bold]Routing:[/bold]")
                     console.print(
                         "  Routed to: "
                         f"{result.routing_decision.get('subagent_to_run')}"
-                        f"{' --mode ' + result.routing_decision.get('mode') if result.routing_decision.get('mode') else ''}"
+                        f"{routing_mode_suffix}"
                     )
                     console.print(
-                        "  Router reasoning: "
-                        f"{result.routing_decision.get('reasoning') or 'n/a'}"
+                        f"  Router reasoning: {result.routing_decision.get('reasoning') or 'n/a'}"
                     )
 
     except Exception as e:
@@ -716,10 +715,7 @@ def doctor(
 
     if provider_filters:
         requested = [
-            item.strip()
-            for raw in provider_filters
-            for item in raw.split(",")
-            if item.strip()
+            item.strip() for raw in provider_filters for item in raw.split(",") if item.strip()
         ]
         selected: list[str] = []
         for requested_name in requested:
@@ -1081,13 +1077,15 @@ def _build_eval_base_config(
     max_retries_override: int | None = None,
     runtime_profile: RuntimeProfile = RuntimeProfile.DEFAULT,
     reasoning_profile: ReasoningProfile = ReasoningProfile.DEFAULT,
-):
+) -> CouncilConfig:
     """Build the shared CouncilConfig used by eval commands."""
 
     from llm_council.protocol.types import CouncilConfig
 
     model_list = [m.strip() for m in models.split(",") if m.strip()] if models else None
-    effective_timeout = timeout_override if timeout_override is not None else config_defaults.get("timeout", 120)
+    effective_timeout = (
+        timeout_override if timeout_override is not None else config_defaults.get("timeout", 120)
+    )
     max_retries = (
         max_retries_override
         if max_retries_override is not None

--- a/src/llm_council/cli/main.py
+++ b/src/llm_council/cli/main.py
@@ -3,6 +3,9 @@ CLI entry point for LLM Council.
 
 Commands:
     council run <subagent> <task>  - Run a council task
+    council eval <dataset>         - Run a dataset-driven evaluation
+    council eval-compare           - Compare named runtime variants on one dataset
+    council eval-import-pr         - Import PR review material into local-only storage
     council doctor                  - Check provider status
     council config                  - Manage configuration
 """
@@ -25,6 +28,16 @@ from rich.panel import Panel
 from rich.table import Table
 
 from llm_council import __version__
+from llm_council.eval_import import import_github_pr_review
+from llm_council.evaluation import (
+    EvalComparisonReport,
+    EvalReport,
+    load_eval_dataset,
+    load_eval_variants,
+    run_eval_comparison,
+    run_eval_dataset,
+)
+from llm_council.protocol.types import ReasoningProfile, RuntimeProfile
 
 # Global state for CLI context
 _cli_state: dict[str, Any] = {
@@ -300,6 +313,20 @@ def run(
         int | None,
         typer.Option("--max-tokens", help="Max output tokens"),
     ] = None,
+    runtime_profile: Annotated[
+        RuntimeProfile,
+        typer.Option(
+            "--runtime-profile",
+            help="High-level runtime budget override: default or bounded",
+        ),
+    ] = RuntimeProfile.DEFAULT,
+    reasoning_profile: Annotated[
+        ReasoningProfile,
+        typer.Option(
+            "--reasoning-profile",
+            help="High-level reasoning override: default, off, or light",
+        ),
+    ] = ReasoningProfile.DEFAULT,
     input_file: Annotated[
         str | None,
         typer.Option("--input", "-i", help="Read task from file (use '-' for stdin)"),
@@ -328,6 +355,13 @@ def run(
         Path | None,
         typer.Option("--schema", help="Custom output schema JSON file"),
     ] = None,
+    route: Annotated[
+        bool,
+        typer.Option(
+            "--route",
+            help="When running router, execute the routed subagent and mode after classification",
+        ),
+    ] = False,
 ) -> None:
     """Run a council task with the specified subagent."""
     console = _get_console()
@@ -393,6 +427,9 @@ def run(
 
     # Resolve agent aliases
     resolved_agent, resolved_mode, was_deprecated = _resolve_agent_alias(subagent, mode)
+    if route and resolved_agent != "router":
+        console.print("[red]Error:[/red] --route can only be used with the router subagent")
+        raise typer.Exit(1)
 
     # Show deprecation warning
     if was_deprecated and not output_json:
@@ -416,6 +453,17 @@ def run(
 
     # Handle dry-run
     if dry_run:
+        effective_schema = schema_file
+        if not effective_schema:
+            try:
+                from llm_council.subagents import get_effective_schema, load_subagent
+
+                effective_schema = get_effective_schema(
+                    load_subagent(resolved_agent), resolved_mode
+                ) or "default"
+            except Exception:
+                effective_schema = "default"
+
         _print(f"[bold]Dry run:[/bold] would execute {resolved_agent}")
         _print(f"  Mode: {resolved_mode or 'default'}")
         _print(f"  Providers: {', '.join(provider_list)}")
@@ -423,9 +471,12 @@ def run(
         _print(f"  Timeout: {effective_timeout}s")
         _print(f"  Temperature: {temperature if temperature is not None else 'default'}")
         _print(f"  Max tokens: {max_tokens if max_tokens is not None else 'default'}")
+        _print(f"  Runtime profile: {runtime_profile.value}")
+        _print(f"  Reasoning profile: {reasoning_profile.value}")
         ctx_display = context[:50] + "..." if context and len(context) > 50 else context or "none"
         _print(f"  Context: {ctx_display}")
-        _print(f"  Schema: {schema_file or 'default'}")
+        _print(f"  Schema: {effective_schema}")
+        _print(f"  Follow router: {'yes' if route else 'no'}")
         _print(f"  Task: {task_text[:100]}{'...' if len(task_text) > 100 else ''}")
         return
 
@@ -465,13 +516,18 @@ def run(
             mode=resolved_mode,
             temperature=temperature,
             max_tokens=max_tokens,
+            runtime_profile=runtime_profile,
+            reasoning_profile=reasoning_profile,
             system_context=context,
             output_schema=custom_schema,
+            follow_router=route,
             provider_configs=_load_provider_configs(),
         )
 
         council = Council(config=config)
-        result = asyncio.run(council.run(task=task_text, subagent=resolved_agent))
+        result = asyncio.run(
+            council.run(task=task_text, subagent=resolved_agent, follow_router=route)
+        )
 
         # Format output
         if output_json:
@@ -513,6 +569,92 @@ def run(
                 console.print(f"  Attempts: {result.synthesis_attempts}")
                 if result.cost_estimate:
                     console.print(f"  Est. cost: ${result.cost_estimate.estimated_cost_usd:.4f}")
+                if result.execution_plan:
+                    console.print("\n[bold]Execution Plan:[/bold]")
+                    console.print(
+                        f"  Mode: {result.execution_plan.get('mode') or resolved_mode or 'default'}"
+                    )
+                    console.print(
+                        f"  Schema: {result.execution_plan.get('schema_name') or 'none'} "
+                        f"({result.execution_plan.get('schema_source') or 'unknown'})"
+                    )
+                    console.print(
+                        f"  Model pack: {result.execution_plan.get('model_pack') or 'default'} "
+                        f"({result.execution_plan.get('model_pack_source') or 'unknown'})"
+                    )
+                    console.print(
+                        "  Execution profile: "
+                        f"{result.execution_plan.get('execution_profile') or 'prompt_only'}"
+                    )
+                    console.print(
+                        f"  Runtime profile: {result.execution_plan.get('runtime_profile') or 'default'}"
+                    )
+                    console.print(
+                        f"  Budget class: {result.execution_plan.get('budget_class') or 'normal'}"
+                    )
+                    providers_display = result.execution_plan.get("providers") or provider_list
+                    console.print(f"  Providers: {', '.join(providers_display)}")
+                    required_capabilities = result.execution_plan.get("required_capabilities") or []
+                    if required_capabilities:
+                        console.print(
+                            "  Required capabilities: " + ", ".join(required_capabilities)
+                        )
+                    registered_tools = result.execution_plan.get("registered_tools") or []
+                    if registered_tools:
+                        console.print("  Registered tools: " + ", ".join(registered_tools))
+                    evidence_items = result.execution_plan.get("evidence_items")
+                    if evidence_items:
+                        console.print(f"  Evidence items: {evidence_items}")
+                    executed_capabilities = result.execution_plan.get("executed_capabilities") or []
+                    if executed_capabilities:
+                        console.print(
+                            "  Executed capabilities: " + ", ".join(executed_capabilities)
+                        )
+                    pending_capabilities = result.execution_plan.get("pending_capabilities") or []
+                    if pending_capabilities:
+                        console.print(
+                            "  Pending capabilities: " + ", ".join(pending_capabilities)
+                        )
+                    model_overrides = result.execution_plan.get("model_overrides") or {}
+                    if model_overrides:
+                        console.print(
+                            "  Model overrides: "
+                            + ", ".join(
+                                f"{provider}={model}"
+                                for provider, model in sorted(model_overrides.items())
+                            )
+                        )
+                    reasoning = result.execution_plan.get("reasoning")
+                    reasoning_profile_used = result.execution_plan.get("reasoning_profile")
+                    if reasoning_profile_used:
+                        console.print(f"  Reasoning profile: {reasoning_profile_used}")
+                    phase_token_budgets = result.execution_plan.get("phase_token_budgets") or {}
+                    if phase_token_budgets:
+                        console.print(
+                            "  Phase token budgets: "
+                            + ", ".join(
+                                f"{phase}={tokens}"
+                                for phase, tokens in phase_token_budgets.items()
+                            )
+                        )
+                    if reasoning:
+                        console.print(
+                            "  Reasoning: "
+                            + ", ".join(
+                                f"{key}={value}" for key, value in reasoning.items() if value is not None
+                            )
+                        )
+                if result.routed and result.routing_decision:
+                    console.print("\n[bold]Routing:[/bold]")
+                    console.print(
+                        "  Routed to: "
+                        f"{result.routing_decision.get('subagent_to_run')}"
+                        f"{' --mode ' + result.routing_decision.get('mode') if result.routing_decision.get('mode') else ''}"
+                    )
+                    console.print(
+                        "  Router reasoning: "
+                        f"{result.routing_decision.get('reasoning') or 'n/a'}"
+                    )
 
     except Exception as e:
         if output_json:
@@ -533,10 +675,28 @@ def doctor(
         bool,
         typer.Option("--json", help="Output as JSON"),
     ] = False,
-    provider_filter: Annotated[
-        str | None,
-        typer.Option("--provider", help="Check specific provider only"),
+    provider_filters: Annotated[
+        list[str] | None,
+        typer.Option("--provider", help="Check one or more specific providers"),
     ] = None,
+    deep: Annotated[
+        bool,
+        typer.Option(
+            "--deep",
+            help=(
+                "Run a low-cost non-interactive generation probe after the normal provider health "
+                "check. This may incur API/CLI usage."
+            ),
+        ),
+    ] = False,
+    probe_timeout: Annotated[
+        float,
+        typer.Option(
+            "--probe-timeout",
+            min=1.0,
+            help="Timeout in seconds for the deep readiness probe",
+        ),
+    ] = 5.0,
 ) -> None:
     """Check provider availability and configuration."""
     console = _get_console()
@@ -554,15 +714,33 @@ def doctor(
     registry = get_registry()
     provider_names = registry.list_providers()
 
-    if provider_filter:
-        if provider_filter not in provider_names:
-            if output_json:
-                print(json.dumps({"error": f"Unknown provider: {provider_filter}"}))
-            else:
-                console.print(f"[red]Error:[/red] Unknown provider: {provider_filter}")
-                console.print(f"Available: {', '.join(provider_names)}")
-            raise typer.Exit(1)
-        provider_names = [provider_filter]
+    if provider_filters:
+        requested = [
+            item.strip()
+            for raw in provider_filters
+            for item in raw.split(",")
+            if item.strip()
+        ]
+        selected: list[str] = []
+        for requested_name in requested:
+            normalized = registry.resolve_name(requested_name)
+            if normalized not in provider_names:
+                if output_json:
+                    print(
+                        json.dumps(
+                            {
+                                "error": f"Unknown provider: {requested_name}",
+                                "available": provider_names,
+                            }
+                        )
+                    )
+                else:
+                    console.print(f"[red]Error:[/red] Unknown provider: {requested_name}")
+                    console.print(f"Available: {', '.join(provider_names)}")
+                raise typer.Exit(1)
+            if normalized not in selected:
+                selected.append(normalized)
+        provider_names = selected
 
     if not provider_names:
         if output_json:
@@ -575,24 +753,74 @@ def doctor(
     # Load per-provider config so doctor shows configured models
     provider_cfgs = _load_provider_configs()
 
+    async def _run_deep_probe(provider: Any) -> dict[str, Any]:
+        from time import perf_counter
+
+        from llm_council.providers.base import GenerateRequest
+
+        start = perf_counter()
+        response = await provider.generate(
+            GenerateRequest(
+                prompt="Reply with OK and nothing else.",
+                timeout_seconds=probe_timeout,
+            )
+        )
+        latency_ms = round((perf_counter() - start) * 1000, 1)
+        text = (response.text if hasattr(response, "text") else str(response)).strip()
+        return {
+            "probe_ok": True,
+            "probe_message": text[:120] or "Probe completed",
+            "probe_latency_ms": latency_ms,
+        }
+
     async def _check_provider(name: str) -> dict[str, Any]:
         try:
             kwargs = provider_cfgs.get(name, {})
             provider = registry.get_provider(name, **kwargs)
             result = await provider.doctor()
-            return {
+            payload = {
                 "name": name,
                 "ok": result.ok,
                 "message": result.message or "",
                 "latency_ms": result.latency_ms,
             }
+            if deep:
+                if result.ok:
+                    try:
+                        payload.update(await _run_deep_probe(provider))
+                    except Exception as e:
+                        payload.update(
+                            {
+                                "probe_ok": False,
+                                "probe_message": str(e),
+                                "probe_latency_ms": None,
+                            }
+                        )
+                else:
+                    payload.update(
+                        {
+                            "probe_ok": False,
+                            "probe_message": "Skipped because base doctor failed",
+                            "probe_latency_ms": None,
+                        }
+                    )
+            return payload
         except Exception as e:
-            return {
+            payload = {
                 "name": name,
                 "ok": False,
                 "message": str(e),
                 "latency_ms": None,
             }
+            if deep:
+                payload.update(
+                    {
+                        "probe_ok": False,
+                        "probe_message": "Skipped because provider initialization failed",
+                        "probe_latency_ms": None,
+                    }
+                )
+            return payload
 
     async def _run_all_checks() -> list[dict[str, Any]]:
         return await asyncio.gather(*[_check_provider(n) for n in provider_names])
@@ -607,13 +835,462 @@ def doctor(
         table.add_column("Status")
         table.add_column("Message")
         table.add_column("Latency")
+        if deep:
+            table.add_column("Probe")
+            table.add_column("Probe Latency")
 
         for r in results:
             status = "[green]OK[/green]" if r["ok"] else "[red]FAIL[/red]"
             latency = f"{r['latency_ms']:.0f}ms" if r["latency_ms"] else "-"
-            table.add_row(r["name"], status, r["message"] or "-", latency)
+            row = [r["name"], status, r["message"] or "-", latency]
+            if deep:
+                probe_status = "[green]OK[/green]" if r.get("probe_ok") else "[red]FAIL[/red]"
+                probe_latency = (
+                    f"{r['probe_latency_ms']:.0f}ms" if r.get("probe_latency_ms") else "-"
+                )
+                row.extend([f"{probe_status} {r.get('probe_message') or '-'}", probe_latency])
+            table.add_row(*row)
 
         console.print(table)
+
+
+@app.command("eval")
+def evaluate(
+    dataset_path: Annotated[
+        Path,
+        typer.Argument(help="Path to an evaluation dataset (.yaml, .yml, or .json)"),
+    ],
+    providers: Annotated[
+        str | None,
+        typer.Option("--providers", "-p", help="Comma-separated provider list"),
+    ] = None,
+    models: Annotated[
+        str | None,
+        typer.Option("--models", "-m", help="Comma-separated model IDs for multi-model council"),
+    ] = None,
+    timeout: Annotated[
+        int | None,
+        typer.Option("--timeout", help="Override per-provider timeout in seconds"),
+    ] = None,
+    max_retries: Annotated[
+        int | None,
+        typer.Option("--max-retries", help="Override synthesis retry count"),
+    ] = None,
+    runtime_profile: Annotated[
+        RuntimeProfile,
+        typer.Option(
+            "--runtime-profile",
+            help="High-level runtime budget override for eval runs: default or bounded",
+        ),
+    ] = RuntimeProfile.DEFAULT,
+    reasoning_profile: Annotated[
+        ReasoningProfile,
+        typer.Option(
+            "--reasoning-profile",
+            help="High-level reasoning override for eval runs: default, off, or light",
+        ),
+    ] = ReasoningProfile.DEFAULT,
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Output as JSON"),
+    ] = False,
+    output_file: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write report to file"),
+    ] = None,
+    case_ids: Annotated[
+        list[str] | None,
+        typer.Option("--case", help="Restrict eval to one or more case IDs"),
+    ] = None,
+    max_cases: Annotated[
+        int | None,
+        typer.Option("--max-cases", help="Run only the first N selected cases"),
+    ] = None,
+    fail_fast: Annotated[
+        bool,
+        typer.Option("--fail-fast", help="Stop on the first failing case"),
+    ] = False,
+) -> None:
+    """Run a dataset-driven evaluation and emit per-mode scorecards."""
+    console = _get_console()
+
+    # Apply output_format default from config (CLI flag takes precedence)
+    if not output_json:
+        config_defaults = _load_config_defaults()
+        output_json = config_defaults.get("output_format") == "json"
+    else:
+        config_defaults = _load_config_defaults()
+
+    if providers:
+        provider_list = [p.strip() for p in providers.split(",") if p.strip()]
+    else:
+        provider_list = config_defaults.get("providers", ["openrouter"])
+
+    try:
+        dataset = load_eval_dataset(dataset_path)
+        base_config = _build_eval_base_config(
+            provider_list,
+            models,
+            config_defaults,
+            timeout_override=timeout,
+            max_retries_override=max_retries,
+            runtime_profile=runtime_profile,
+            reasoning_profile=reasoning_profile,
+        )
+        report = asyncio.run(
+            run_eval_dataset(
+                dataset,
+                base_config=base_config,
+                case_ids=case_ids,
+                max_cases=max_cases,
+                fail_fast=fail_fast,
+            )
+        )
+    except Exception as e:
+        if output_json:
+            print(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    _emit_eval_report(report, output_json=output_json, output_file=output_file)
+    if report.failed_cases:
+        raise typer.Exit(1)
+
+
+@app.command("eval-compare")
+def evaluate_compare(
+    dataset_path: Annotated[
+        Path,
+        typer.Argument(help="Path to an evaluation dataset (.yaml, .yml, or .json)"),
+    ],
+    variants_path: Annotated[
+        Path,
+        typer.Argument(help="Path to a named variant file (.yaml, .yml, or .json)"),
+    ],
+    providers: Annotated[
+        str | None,
+        typer.Option("--providers", "-p", help="Base comma-separated provider list"),
+    ] = None,
+    models: Annotated[
+        str | None,
+        typer.Option("--models", "-m", help="Base comma-separated model IDs"),
+    ] = None,
+    timeout: Annotated[
+        int | None,
+        typer.Option("--timeout", help="Override per-provider timeout in seconds"),
+    ] = None,
+    max_retries: Annotated[
+        int | None,
+        typer.Option("--max-retries", help="Override synthesis retry count"),
+    ] = None,
+    runtime_profile: Annotated[
+        RuntimeProfile,
+        typer.Option(
+            "--runtime-profile",
+            help="High-level runtime budget override for compare runs: default or bounded",
+        ),
+    ] = RuntimeProfile.DEFAULT,
+    reasoning_profile: Annotated[
+        ReasoningProfile,
+        typer.Option(
+            "--reasoning-profile",
+            help="High-level reasoning override for compare runs: default, off, or light",
+        ),
+    ] = ReasoningProfile.DEFAULT,
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Output as JSON"),
+    ] = False,
+    output_file: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write report to file"),
+    ] = None,
+    variant_names: Annotated[
+        list[str] | None,
+        typer.Option("--variant", help="Restrict compare to one or more named variants"),
+    ] = None,
+    case_ids: Annotated[
+        list[str] | None,
+        typer.Option("--case", help="Restrict eval to one or more case IDs"),
+    ] = None,
+    max_cases: Annotated[
+        int | None,
+        typer.Option("--max-cases", help="Run only the first N selected cases"),
+    ] = None,
+    fail_fast: Annotated[
+        bool,
+        typer.Option("--fail-fast", help="Stop on the first failing case"),
+    ] = False,
+) -> None:
+    """Compare multiple named runtime variants on the same evaluation dataset."""
+    console = _get_console()
+
+    if not output_json:
+        config_defaults = _load_config_defaults()
+        output_json = config_defaults.get("output_format") == "json"
+    else:
+        config_defaults = _load_config_defaults()
+
+    if providers:
+        provider_list = [p.strip() for p in providers.split(",") if p.strip()]
+    else:
+        provider_list = config_defaults.get("providers", ["openrouter"])
+
+    try:
+        dataset = load_eval_dataset(dataset_path)
+        variants = load_eval_variants(variants_path)
+        base_config = _build_eval_base_config(
+            provider_list,
+            models,
+            config_defaults,
+            timeout_override=timeout,
+            max_retries_override=max_retries,
+            runtime_profile=runtime_profile,
+            reasoning_profile=reasoning_profile,
+        )
+        report = asyncio.run(
+            run_eval_comparison(
+                dataset,
+                variants,
+                base_config=base_config,
+                variant_names=variant_names,
+                case_ids=case_ids,
+                max_cases=max_cases,
+                fail_fast=fail_fast,
+            )
+        )
+    except Exception as e:
+        if output_json:
+            print(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    _emit_eval_comparison_report(report, output_json=output_json, output_file=output_file)
+    if any(item.report.failed_cases for item in report.variant_results):
+        raise typer.Exit(1)
+
+
+def _build_eval_base_config(
+    provider_list: list[str],
+    models: str | None,
+    config_defaults: dict[str, Any],
+    *,
+    timeout_override: int | None = None,
+    max_retries_override: int | None = None,
+    runtime_profile: RuntimeProfile = RuntimeProfile.DEFAULT,
+    reasoning_profile: ReasoningProfile = ReasoningProfile.DEFAULT,
+):
+    """Build the shared CouncilConfig used by eval commands."""
+
+    from llm_council.protocol.types import CouncilConfig
+
+    model_list = [m.strip() for m in models.split(",") if m.strip()] if models else None
+    effective_timeout = timeout_override if timeout_override is not None else config_defaults.get("timeout", 120)
+    max_retries = (
+        max_retries_override
+        if max_retries_override is not None
+        else config_defaults.get("max_retries", 3)
+    )
+    enable_degradation = config_defaults.get("enable_degradation", True)
+
+    return CouncilConfig(
+        providers=provider_list,
+        models=model_list,
+        timeout=effective_timeout,
+        max_retries=max_retries,
+        enable_artifact_store=True,
+        enable_health_check=False,
+        enable_graceful_degradation=enable_degradation,
+        runtime_profile=runtime_profile,
+        reasoning_profile=reasoning_profile,
+        provider_configs=_load_provider_configs(),
+    )
+
+
+def _emit_eval_report(
+    report: EvalReport,
+    *,
+    output_json: bool,
+    output_file: Path | None,
+) -> None:
+    """Render an evaluation report to stdout and optionally to a file."""
+
+    console = _get_console()
+    payload = report.model_dump()
+
+    if output_file:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        if output_json:
+            output_file.write_text(json.dumps(payload, indent=2, default=str))
+        else:
+            output_file.write_text(json.dumps(payload, indent=2, default=str))
+
+    if output_json:
+        print(json.dumps(payload, indent=2, default=str))
+        return
+
+    summary = (
+        f"Cases: {report.passed_cases}/{report.total_cases} passed\n"
+        f"Criteria: {report.passed_criteria}/{report.total_criteria} passed\n"
+        f"Duration: {report.duration_ms}ms"
+    )
+    title = f"[green]Eval: {report.dataset_name}[/green]"
+    border_style = "green" if report.failed_cases == 0 else "yellow"
+    console.print(Panel(summary, title=title, border_style=border_style))
+
+    table = Table(title="Per-Mode Scorecards")
+    table.add_column("Mode", style="cyan")
+    table.add_column("Cases")
+    table.add_column("Case Pass Rate")
+    table.add_column("Criteria Pass Rate")
+    table.add_column("Avg Duration")
+
+    for item in report.mode_scorecards:
+        table.add_row(
+            item.mode_key,
+            f"{item.passed_cases}/{item.total_cases}",
+            f"{item.case_pass_rate:.0%}",
+            f"{item.criteria_pass_rate:.0%}",
+            f"{item.average_duration_ms}ms",
+        )
+    console.print(table)
+
+    failing_cases = [case for case in report.case_results if not case.passed]
+    if failing_cases:
+        console.print("\n[bold]Failing Cases:[/bold]")
+        for case in failing_cases:
+            failures = [criterion for criterion in case.criteria if not criterion.passed]
+            failure_summary = "; ".join(
+                f"{criterion.name}: {criterion.message or f'expected {criterion.expected!r}, got {criterion.actual!r}'}"
+                for criterion in failures
+            )
+            console.print(f"  - {case.case_id} ({case.mode_key}): {failure_summary}")
+
+
+def _emit_eval_comparison_report(
+    report: EvalComparisonReport,
+    *,
+    output_json: bool,
+    output_file: Path | None,
+) -> None:
+    """Render a comparison report across named runtime variants."""
+
+    console = _get_console()
+    payload = report.model_dump()
+
+    if output_file:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(payload, indent=2, default=str))
+
+    if output_json:
+        print(json.dumps(payload, indent=2, default=str))
+        return
+
+    summary = (
+        f"Dataset: {report.dataset_name}\n"
+        f"Variants: {len(report.variant_results)}\n"
+        f"Best: {report.best_variant or '-'}"
+    )
+    console.print(
+        Panel(
+            summary,
+            title="[green]Eval Comparison[/green]",
+            border_style="green" if report.variant_results else "yellow",
+        )
+    )
+
+    table = Table(title="Variant Ranking")
+    table.add_column("Rank")
+    table.add_column("Variant", style="cyan")
+    table.add_column("Cases")
+    table.add_column("Case Pass Rate")
+    table.add_column("Criteria Pass Rate")
+    table.add_column("Duration")
+    table.add_column("Providers")
+
+    results_by_name = {item.variant_name: item for item in report.variant_results}
+    for index, variant_name in enumerate(report.ranking, start=1):
+        item = results_by_name[variant_name]
+        variant_report = item.report
+        table.add_row(
+            str(index),
+            variant_name,
+            f"{variant_report.passed_cases}/{variant_report.total_cases}",
+            f"{variant_report.case_pass_rate:.0%}",
+            f"{variant_report.criteria_pass_rate:.0%}",
+            f"{variant_report.duration_ms}ms",
+            ", ".join(item.providers),
+        )
+    console.print(table)
+
+
+@app.command()
+def eval_import_pr(
+    repo: Annotated[
+        str,
+        typer.Argument(help="GitHub repo slug, e.g. sherifkozman/eve"),
+    ],
+    pr_number: Annotated[
+        int,
+        typer.Argument(help="Pull request number to import"),
+    ],
+    output_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--output-root",
+            help="Local-only output root. Defaults to .council-private/imports/github",
+        ),
+    ] = None,
+    max_diff_lines: Annotated[
+        int | None,
+        typer.Option("--max-diff-lines", help="Optionally truncate imported patch to N lines"),
+    ] = None,
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Output as JSON"),
+    ] = False,
+) -> None:
+    """Import a PR diff and Greptile review labels into local-only storage."""
+    console = _get_console()
+
+    try:
+        imported = import_github_pr_review(
+            repo,
+            pr_number,
+            output_root=output_root,
+            max_diff_lines=max_diff_lines,
+        )
+    except Exception as e:
+        if output_json:
+            print(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    payload = imported.model_dump()
+    if output_json:
+        print(json.dumps(payload, indent=2, default=str))
+        return
+
+    console.print(
+        Panel(
+            "\n".join(
+                [
+                    f"Repo: {imported.repo}",
+                    f"PR: {imported.pr_number}",
+                    f"Title: {imported.title}",
+                    f"Imported Greptile comments: {imported.imported_comment_count}",
+                    f"Import root: {imported.import_root}",
+                    f"Review input: {imported.review_input_path}",
+                    f"Labels: {imported.greptile_labels_path}",
+                ]
+            ),
+            title="[green]PR Import Complete[/green]",
+            border_style="green",
+        )
+    )
 
 
 @app.command()

--- a/src/llm_council/config/models.py
+++ b/src/llm_council/config/models.py
@@ -210,6 +210,14 @@ def get_model_for_pack(pack: ModelPack) -> str:
     return ModelConfig.get_instance().get_model_for_pack(pack)
 
 
+def normalize_model_pack(model_pack: str | ModelPack) -> ModelPack:
+    """Normalize a model pack string or enum into a ModelPack value."""
+
+    if isinstance(model_pack, ModelPack):
+        return model_pack
+    return resolve_model_pack(model_pack)
+
+
 def is_multi_model_enabled() -> bool:
     """Check if multi-model council is enabled.
 

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -120,16 +120,34 @@ class Council:
         routed_subagent = router_result.output.get("subagent_to_run")
         routed_mode = router_result.output.get("mode")
 
-        if routed_subagent in (None, "", "router"):
+        if not isinstance(routed_subagent, str) or routed_subagent in ("", "router"):
             return router_result
+
+        routed_mode_value = routed_mode if isinstance(routed_mode, str) else None
+        routing_model_pack = router_result.output.get("model_pack")
+        routing_execution_profile = router_result.output.get("execution_profile")
+        routing_budget_class = router_result.output.get("budget_class")
+        routing_required_capabilities = router_result.output.get("required_capabilities")
 
         routed_config = self.config.model_copy(
             update={
-                "mode": routed_mode,
-                "model_pack": router_result.output.get("model_pack"),
-                "execution_profile": router_result.output.get("execution_profile"),
-                "budget_class": router_result.output.get("budget_class"),
-                "required_capabilities": list(router_result.output.get("required_capabilities") or []),
+                "mode": routed_mode_value,
+                "model_pack": routing_model_pack if isinstance(routing_model_pack, str) else None,
+                "execution_profile": (
+                    routing_execution_profile
+                    if isinstance(routing_execution_profile, str)
+                    else None
+                ),
+                "budget_class": routing_budget_class
+                if isinstance(routing_budget_class, str)
+                else None,
+                "required_capabilities": [
+                    capability
+                    for capability in routing_required_capabilities
+                    if isinstance(capability, str)
+                ]
+                if isinstance(routing_required_capabilities, list)
+                else [],
             }
         )
         routed_orchestrator = self._build_orchestrator(routed_config)
@@ -139,16 +157,12 @@ class Council:
             routed_result.execution_plan = {}
         routed_result.execution_plan["routed_via_router"] = True
         routed_result.execution_plan["routing_subagent"] = routed_subagent
-        routed_result.execution_plan["routing_mode"] = routed_mode
-        routed_result.execution_plan["routing_model_pack"] = router_result.output.get("model_pack")
-        routed_result.execution_plan["routing_execution_profile"] = router_result.output.get(
-            "execution_profile"
-        )
-        routed_result.execution_plan["routing_budget_class"] = router_result.output.get(
-            "budget_class"
-        )
-        routed_result.execution_plan["routing_required_capabilities"] = router_result.output.get(
-            "required_capabilities"
+        routed_result.execution_plan["routing_mode"] = routed_mode_value
+        routed_result.execution_plan["routing_model_pack"] = routing_model_pack
+        routed_result.execution_plan["routing_execution_profile"] = routing_execution_profile
+        routed_result.execution_plan["routing_budget_class"] = routing_budget_class
+        routed_result.execution_plan["routing_required_capabilities"] = (
+            routing_required_capabilities
         )
 
         routed_result.routed = True

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -41,37 +41,120 @@ class Council:
             config: Optional configuration override.
         """
         self._providers = providers or (config.providers if config else ["openrouter"])
+        self.config = (
+            config.model_copy(update={"providers": self._providers})
+            if config
+            else CouncilConfig(providers=self._providers)
+        )
+        self._orchestrator = self._build_orchestrator(self.config)
 
-        # Convert CouncilConfig to OrchestratorConfig
-        orch_config = OrchestratorConfig(
-            timeout=config.timeout if config else 120,
-            max_retries=config.max_retries if config else 3,
-            enable_artifacts=(config.enable_artifact_store if config else True),
-            enable_health_check=(config.enable_health_check if config else False),
-            enable_graceful_degradation=(config.enable_graceful_degradation if config else True),
-            models=config.models if config else None,
-            provider_configs=(config.provider_configs if config else {}),
-            system_context=(config.system_context if config else None),
+    def _build_orchestrator_config(self, config: CouncilConfig) -> OrchestratorConfig:
+        """Convert CouncilConfig to OrchestratorConfig."""
+
+        return OrchestratorConfig(
+            timeout=config.timeout,
+            max_retries=config.max_retries,
+            enable_artifacts=config.enable_artifact_store,
+            enable_health_check=config.enable_health_check,
+            enable_graceful_degradation=config.enable_graceful_degradation,
+            models=config.models,
+            provider_configs=config.provider_configs,
+            system_context=config.system_context,
+            mode=config.mode,
+            model_pack=config.model_pack,
+            model_overrides=dict(config.model_overrides),
+            reasoning_profile=config.reasoning_profile,
+            execution_profile=config.execution_profile,
+            budget_class=config.budget_class,
+            required_capabilities=list(config.required_capabilities),
+            disable_local_evidence=config.disable_local_evidence,
+            temperature=config.temperature,
+            max_tokens=config.max_tokens,
+            runtime_profile=config.runtime_profile,
+            output_schema=config.output_schema,
         )
 
-        self.config = config or CouncilConfig(providers=self._providers)
-        self._orchestrator = Orchestrator(providers=self._providers, config=orch_config)
+    def _build_orchestrator(self, config: CouncilConfig) -> Orchestrator:
+        """Create an orchestrator instance from CouncilConfig."""
+
+        return Orchestrator(
+            providers=config.providers,
+            config=self._build_orchestrator_config(config),
+        )
 
     async def run(
         self,
         task: str,
         subagent: str = "router",
+        *,
+        follow_router: bool | None = None,
     ) -> CouncilResult:
         """Run a council task.
 
         Args:
             task: The task description.
             subagent: Subagent type (router, planner, implementer, etc.).
+            follow_router: When true, execute the router recommendation after a router run.
 
         Returns:
             CouncilResult with the result.
         """
-        return await self._orchestrator.run(task=task, subagent=subagent)
+        effective_follow_router = (
+            follow_router if follow_router is not None else self.config.follow_router
+        )
+        if effective_follow_router and subagent != "router":
+            raise ValueError("follow_router can only be used when subagent='router'")
+
+        initial_result = await self._orchestrator.run(task=task, subagent=subagent)
+        if not effective_follow_router:
+            return initial_result
+
+        return await self._run_router_follow_up(task, initial_result)
+
+    async def _run_router_follow_up(self, task: str, router_result: CouncilResult) -> CouncilResult:
+        """Run the subagent selected by the router, if the router result is usable."""
+
+        if not router_result.success or not isinstance(router_result.output, dict):
+            return router_result
+
+        routed_subagent = router_result.output.get("subagent_to_run")
+        routed_mode = router_result.output.get("mode")
+
+        if routed_subagent in (None, "", "router"):
+            return router_result
+
+        routed_config = self.config.model_copy(
+            update={
+                "mode": routed_mode,
+                "model_pack": router_result.output.get("model_pack"),
+                "execution_profile": router_result.output.get("execution_profile"),
+                "budget_class": router_result.output.get("budget_class"),
+                "required_capabilities": list(router_result.output.get("required_capabilities") or []),
+            }
+        )
+        routed_orchestrator = self._build_orchestrator(routed_config)
+        routed_result = await routed_orchestrator.run(task=task, subagent=routed_subagent)
+
+        if routed_result.execution_plan is None:
+            routed_result.execution_plan = {}
+        routed_result.execution_plan["routed_via_router"] = True
+        routed_result.execution_plan["routing_subagent"] = routed_subagent
+        routed_result.execution_plan["routing_mode"] = routed_mode
+        routed_result.execution_plan["routing_model_pack"] = router_result.output.get("model_pack")
+        routed_result.execution_plan["routing_execution_profile"] = router_result.output.get(
+            "execution_profile"
+        )
+        routed_result.execution_plan["routing_budget_class"] = router_result.output.get(
+            "budget_class"
+        )
+        routed_result.execution_plan["routing_required_capabilities"] = router_result.output.get(
+            "required_capabilities"
+        )
+
+        routed_result.routed = True
+        routed_result.routing_decision = dict(router_result.output)
+        routed_result.routing_execution_plan = dict(router_result.execution_plan or {})
+        return routed_result
 
     async def doctor(self) -> dict[str, Any]:
         """Check provider availability.

--- a/src/llm_council/engine/__init__.py
+++ b/src/llm_council/engine/__init__.py
@@ -8,6 +8,7 @@ The engine coordinates:
 4. Health checks and graceful degradation
 """
 
+from llm_council.engine.capabilities import CapabilityPlan, select_capability_plan
 from llm_council.engine.degradation import (
     DegradationAction,
     DegradationDecision,
@@ -16,7 +17,7 @@ from llm_council.engine.degradation import (
     FailureEvent,
     create_default_policy,
 )
-from llm_council.engine.capabilities import CapabilityPlan, select_capability_plan
+from llm_council.engine.evidence import EvidenceBundle, EvidenceItem, collect_capability_evidence
 from llm_council.engine.health import (
     HealthChecker,
     HealthReport,
@@ -24,7 +25,6 @@ from llm_council.engine.health import (
     ProviderHealth,
     preflight_check,
 )
-from llm_council.engine.evidence import EvidenceBundle, EvidenceItem, collect_capability_evidence
 from llm_council.engine.orchestrator import Orchestrator
 
 __all__ = [

--- a/src/llm_council/engine/__init__.py
+++ b/src/llm_council/engine/__init__.py
@@ -16,6 +16,7 @@ from llm_council.engine.degradation import (
     FailureEvent,
     create_default_policy,
 )
+from llm_council.engine.capabilities import CapabilityPlan, select_capability_plan
 from llm_council.engine.health import (
     HealthChecker,
     HealthReport,
@@ -23,11 +24,17 @@ from llm_council.engine.health import (
     ProviderHealth,
     preflight_check,
 )
+from llm_council.engine.evidence import EvidenceBundle, EvidenceItem, collect_capability_evidence
 from llm_council.engine.orchestrator import Orchestrator
 
 __all__ = [
     # Orchestrator
     "Orchestrator",
+    "CapabilityPlan",
+    "select_capability_plan",
+    "EvidenceBundle",
+    "EvidenceItem",
+    "collect_capability_evidence",
     # Health checks
     "HealthChecker",
     "HealthStatus",

--- a/src/llm_council/engine/capabilities.py
+++ b/src/llm_council/engine/capabilities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -159,11 +159,13 @@ def select_capability_plan(
     registry.ensure_loaded()
 
     plan.tool_names = [
-        tool.name for tool in registry.resolve_capability_tools(plan.required_capabilities, role=subagent)
+        tool.name
+        for tool in registry.resolve_capability_tools(plan.required_capabilities, role=subagent)
     ]
 
     if isinstance(subagent_config, dict):
-        for suggested_tool in subagent_config.get("suggested_tools", []):
+        suggested_tools = subagent_config.get("suggested_tools")
+        for suggested_tool in suggested_tools if isinstance(suggested_tools, list) else []:
             if isinstance(suggested_tool, str) and suggested_tool not in plan.tool_names:
                 plan.tool_names.append(suggested_tool)
 
@@ -194,15 +196,26 @@ def _apply_capability_overrides(
     default policy for a subagent/mode combination.
     """
 
-    if requested_execution_profile in _EXECUTION_PROFILE_ORDER:
-        if _EXECUTION_PROFILE_ORDER[requested_execution_profile] > _EXECUTION_PROFILE_ORDER[
-            plan.execution_profile
-        ]:
-            plan.execution_profile = requested_execution_profile
+    normalized_execution_profile = (
+        cast(ExecutionProfile, requested_execution_profile)
+        if requested_execution_profile in _EXECUTION_PROFILE_ORDER
+        else None
+    )
+    if normalized_execution_profile is not None:
+        if (
+            _EXECUTION_PROFILE_ORDER[normalized_execution_profile]
+            > _EXECUTION_PROFILE_ORDER[plan.execution_profile]
+        ):
+            plan.execution_profile = normalized_execution_profile
 
-    if requested_budget_class in _BUDGET_CLASS_ORDER:
-        if _BUDGET_CLASS_ORDER[requested_budget_class] > _BUDGET_CLASS_ORDER[plan.budget_class]:
-            plan.budget_class = requested_budget_class
+    normalized_budget_class = (
+        cast(BudgetClass, requested_budget_class)
+        if requested_budget_class in _BUDGET_CLASS_ORDER
+        else None
+    )
+    if normalized_budget_class is not None:
+        if _BUDGET_CLASS_ORDER[normalized_budget_class] > _BUDGET_CLASS_ORDER[plan.budget_class]:
+            plan.budget_class = normalized_budget_class
 
     resolved_capability_names: list[str] = []
     for capability_name in requested_capabilities:

--- a/src/llm_council/engine/capabilities.py
+++ b/src/llm_council/engine/capabilities.py
@@ -1,0 +1,250 @@
+"""Capability selection policy for mode-aware council execution."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from llm_council.registry.tool_registry import ToolRegistry, get_tool_registry
+
+ExecutionProfile = Literal["prompt_only", "light_tools", "grounded", "deep_analysis"]
+BudgetClass = Literal["cheap", "normal", "premium"]
+
+
+class CapabilityPlan(BaseModel):
+    """Resolved capability policy for a council run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    execution_profile: ExecutionProfile = "prompt_only"
+    budget_class: BudgetClass = "normal"
+    required_capabilities: list[str] = Field(default_factory=list)
+    tool_names: list[str] = Field(default_factory=list)
+    evidence_requirements: list[str] = Field(default_factory=list)
+
+
+_EXECUTION_PROFILE_ORDER: dict[ExecutionProfile, int] = {
+    "prompt_only": 0,
+    "light_tools": 1,
+    "grounded": 2,
+    "deep_analysis": 3,
+}
+_BUDGET_CLASS_ORDER: dict[BudgetClass, int] = {
+    "cheap": 0,
+    "normal": 1,
+    "premium": 2,
+}
+
+
+_CAPABILITY_POLICY: dict[tuple[str, str | None], CapabilityPlan] = {
+    (
+        "planner",
+        "plan",
+    ): CapabilityPlan(
+        execution_profile="light_tools",
+        budget_class="normal",
+        required_capabilities=["planning-assess", "repo-analysis"],
+        evidence_requirements=[
+            "Identify concrete dependencies, blockers, and sequencing assumptions.",
+            "Call out risks and mitigations explicitly instead of implying them.",
+            "If repository context is missing, state which planning assumptions remain unverified.",
+        ],
+    ),
+    (
+        "planner",
+        "assess",
+    ): CapabilityPlan(
+        execution_profile="grounded",
+        budget_class="premium",
+        required_capabilities=["planning-assess", "docs-research"],
+        evidence_requirements=[
+            "Define explicit evaluation criteria and score tradeoffs against them.",
+            "Name alternatives considered and why they were rejected.",
+            "State reversibility and unresolved external dependencies if evidence is incomplete.",
+        ],
+    ),
+    (
+        "critic",
+        "security",
+    ): CapabilityPlan(
+        execution_profile="deep_analysis",
+        budget_class="premium",
+        required_capabilities=["red-team-recon", "security-code-audit", "repo-analysis"],
+        evidence_requirements=[
+            "Ground findings in realistic attack paths, prerequisites, and affected components.",
+            "Distinguish verified weaknesses from speculative concerns.",
+            "If attack-surface evidence is missing, say so explicitly instead of fabricating exploitability.",
+        ],
+    ),
+    (
+        "critic",
+        "review",
+    ): CapabilityPlan(
+        execution_profile="light_tools",
+        budget_class="normal",
+        required_capabilities=["diff-review", "repo-analysis"],
+        evidence_requirements=[
+            "Tie findings to concrete code locations or behaviors.",
+            "Separate correctness issues from style or preference commentary.",
+        ],
+    ),
+    (
+        "researcher",
+        None,
+    ): CapabilityPlan(
+        execution_profile="grounded",
+        budget_class="normal",
+        required_capabilities=["docs-research"],
+        evidence_requirements=[
+            "Use authoritative sources where possible and state freshness limits.",
+            "Separate verified facts from inference or opinion.",
+        ],
+    ),
+    (
+        "drafter",
+        "impl",
+    ): CapabilityPlan(
+        execution_profile="light_tools",
+        budget_class="normal",
+        required_capabilities=["repo-analysis"],
+        evidence_requirements=[
+            "Follow existing repository patterns where evidence exists.",
+            "Call out any implementation assumptions that could not be verified locally.",
+        ],
+    ),
+    (
+        "drafter",
+        "arch",
+    ): CapabilityPlan(
+        execution_profile="light_tools",
+        budget_class="normal",
+        required_capabilities=["repo-analysis"],
+        evidence_requirements=[
+            "Identify affected boundaries, interfaces, and dependencies explicitly.",
+        ],
+    ),
+    (
+        "drafter",
+        "test",
+    ): CapabilityPlan(
+        execution_profile="light_tools",
+        budget_class="normal",
+        required_capabilities=["repo-analysis"],
+        evidence_requirements=[
+            "Tie proposed tests to concrete code paths, failure cases, and risk areas.",
+        ],
+    ),
+    ("router", None): CapabilityPlan(execution_profile="prompt_only", budget_class="cheap"),
+    ("synthesizer", None): CapabilityPlan(execution_profile="prompt_only", budget_class="cheap"),
+}
+
+
+def select_capability_plan(
+    subagent: str,
+    mode: str | None = None,
+    *,
+    subagent_config: dict[str, object] | None = None,
+    tool_registry: ToolRegistry | None = None,
+    requested_execution_profile: str | None = None,
+    requested_budget_class: str | None = None,
+    requested_capabilities: list[str] | None = None,
+) -> CapabilityPlan:
+    """Resolve the capability plan for a subagent and mode."""
+
+    template = _CAPABILITY_POLICY.get((subagent, mode)) or _CAPABILITY_POLICY.get((subagent, None))
+    plan = template.model_copy(deep=True) if template else CapabilityPlan()
+
+    registry = tool_registry or get_tool_registry()
+    registry.ensure_loaded()
+
+    plan.tool_names = [
+        tool.name for tool in registry.resolve_capability_tools(plan.required_capabilities, role=subagent)
+    ]
+
+    if isinstance(subagent_config, dict):
+        for suggested_tool in subagent_config.get("suggested_tools", []):
+            if isinstance(suggested_tool, str) and suggested_tool not in plan.tool_names:
+                plan.tool_names.append(suggested_tool)
+
+    _apply_capability_overrides(
+        plan,
+        subagent=subagent,
+        registry=registry,
+        requested_execution_profile=requested_execution_profile,
+        requested_budget_class=requested_budget_class,
+        requested_capabilities=requested_capabilities or [],
+    )
+
+    return plan
+
+
+def _apply_capability_overrides(
+    plan: CapabilityPlan,
+    *,
+    subagent: str,
+    registry: ToolRegistry,
+    requested_execution_profile: str | None,
+    requested_budget_class: str | None,
+    requested_capabilities: list[str],
+) -> None:
+    """Safely merge runtime capability overrides into a plan.
+
+    Runtime overrides may strengthen a run, but they should not weaken the
+    default policy for a subagent/mode combination.
+    """
+
+    if requested_execution_profile in _EXECUTION_PROFILE_ORDER:
+        if _EXECUTION_PROFILE_ORDER[requested_execution_profile] > _EXECUTION_PROFILE_ORDER[
+            plan.execution_profile
+        ]:
+            plan.execution_profile = requested_execution_profile
+
+    if requested_budget_class in _BUDGET_CLASS_ORDER:
+        if _BUDGET_CLASS_ORDER[requested_budget_class] > _BUDGET_CLASS_ORDER[plan.budget_class]:
+            plan.budget_class = requested_budget_class
+
+    resolved_capability_names: list[str] = []
+    for capability_name in requested_capabilities:
+        pack = registry.get_capability_pack(capability_name)
+        if pack is None:
+            continue
+        if pack.roles and subagent not in pack.roles:
+            continue
+        if capability_name not in plan.required_capabilities:
+            plan.required_capabilities.append(capability_name)
+            resolved_capability_names.append(capability_name)
+
+    if resolved_capability_names:
+        for requirement in _collect_evidence_requirements(
+            registry,
+            resolved_capability_names,
+            subagent=subagent,
+        ):
+            if requirement not in plan.evidence_requirements:
+                plan.evidence_requirements.append(requirement)
+
+        for tool in registry.resolve_capability_tools(resolved_capability_names, role=subagent):
+            if tool.name not in plan.tool_names:
+                plan.tool_names.append(tool.name)
+
+
+def _collect_evidence_requirements(
+    registry: ToolRegistry, capability_names: list[str], *, subagent: str
+) -> list[str]:
+    """Collect evidence requirements from capability packs valid for the role."""
+
+    requirements: list[str] = []
+    for capability_name in capability_names:
+        pack = registry.get_capability_pack(capability_name)
+        if pack is None:
+            continue
+        if pack.roles and subagent not in pack.roles:
+            continue
+        for requirement in pack.evidence_requirements:
+            if requirement not in requirements:
+                requirements.append(requirement)
+    return requirements
+
+
+__all__ = ["CapabilityPlan", "select_capability_plan"]

--- a/src/llm_council/engine/evidence.py
+++ b/src/llm_council/engine/evidence.py
@@ -492,7 +492,9 @@ def _fetch_docs_page(url: str) -> tuple[str, str] | None:
         return None
 
     content_type = response.headers.get("content-type", "").lower()
-    if not any(token in content_type for token in ("text/html", "text/plain", "application/xhtml+xml")):
+    if not any(
+        token in content_type for token in ("text/html", "text/plain", "application/xhtml+xml")
+    ):
         return None
 
     return _extract_page_summary(response.text, url)
@@ -623,7 +625,10 @@ def _extract_page_summary(content: str, fallback_url: str) -> tuple[str, str]:
         text_content = _clean_text(re.sub(r"<[^>]+>", " ", content))
         summary = text_content[:200].rsplit(" ", 1)[0] if len(text_content) > 200 else text_content
 
-    return title or fallback_url, summary or "Documentation page fetched with no extractable summary."
+    return (
+        title or fallback_url,
+        summary or "Documentation page fetched with no extractable summary.",
+    )
 
 
 def _clean_text(value: str) -> str:

--- a/src/llm_council/engine/evidence.py
+++ b/src/llm_council/engine/evidence.py
@@ -1,0 +1,648 @@
+"""Local evidence collection for capability-backed council runs."""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from llm_council.engine.capabilities import CapabilityPlan
+
+TEXT_EXTENSIONS = {
+    ".py",
+    ".md",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".toml",
+    ".txt",
+    ".tsx",
+    ".ts",
+    ".js",
+    ".jsx",
+    ".sh",
+}
+SEARCH_DIRS = ("src", "tests", "config", "docs")
+STOPWORDS = {
+    "this",
+    "that",
+    "with",
+    "from",
+    "into",
+    "using",
+    "their",
+    "there",
+    "should",
+    "could",
+    "would",
+    "about",
+    "after",
+    "before",
+    "review",
+    "build",
+    "plan",
+    "security",
+    "system",
+    "mode",
+    "task",
+}
+SECURITY_PATTERNS = (
+    "auth",
+    "token",
+    "secret",
+    "password",
+    "session",
+    "cookie",
+    "oauth",
+    "subprocess",
+    "shell",
+    "exec",
+    "eval",
+    "encrypt",
+    "hash",
+    "csrf",
+    "jwt",
+)
+ATTACK_SURFACE_PATTERNS = (
+    "app.get",
+    "app.post",
+    "router.get",
+    "router.post",
+    "apirouter",
+    "@app.",
+    "@router.",
+    "webhook",
+    "callback",
+    "oauth",
+    "login",
+    "session",
+    "admin",
+    "/api/",
+    "graphql",
+    "upload",
+    "public",
+)
+DOCS_TARGETS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("react", "reactjs"), "https://react.dev/reference/react"),
+    (("next.js", "nextjs"), "https://nextjs.org/docs"),
+    (("fastapi",), "https://fastapi.tiangolo.com/"),
+    (("pydantic",), "https://docs.pydantic.dev/latest/"),
+    (("pytest",), "https://docs.pytest.org/en/stable/"),
+    (("typescript",), "https://www.typescriptlang.org/docs/"),
+    (("node.js", "nodejs"), "https://nodejs.org/api/documentation.html"),
+    (("docker",), "https://docs.docker.com/"),
+    (("kubernetes", "k8s"), "https://kubernetes.io/docs/home/"),
+    (("redis",), "https://redis.io/docs/latest/"),
+    (("postgres", "postgresql"), "https://www.postgresql.org/docs/current/index.html"),
+    (("stripe",), "https://docs.stripe.com/api"),
+    (("oauth", "oidc", "openid connect", "sso"), "https://datatracker.ietf.org/doc/html/rfc6749"),
+    (("rate limit", "rate limiting"), "https://datatracker.ietf.org/doc/html/rfc6585"),
+    (("openapi",), "https://spec.openapis.org/oas/latest.html"),
+)
+DOCS_FETCH_LIMIT = 2
+DOCS_TIMEOUT_SECONDS = 5.0
+DOCS_USER_AGENT = "llm-council/0.6 docs-research"
+DIFF_FETCH_TIMEOUT_SECONDS = 5.0
+DIFF_HUNK_LIMIT = 8
+DIFF_FILE_LIMIT = 12
+
+
+class EvidenceItem(BaseModel):
+    """One collected evidence item."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    capability: str
+    title: str
+    summary: str
+    details: list[str] = Field(default_factory=list)
+
+
+class EvidenceBundle(BaseModel):
+    """Collected evidence for a council run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    executed_capabilities: list[str] = Field(default_factory=list)
+    pending_capabilities: list[str] = Field(default_factory=list)
+    items: list[EvidenceItem] = Field(default_factory=list)
+
+    def to_prompt_block(self) -> str:
+        """Render collected evidence as a bounded prompt block."""
+
+        if not self.items and not self.pending_capabilities:
+            return ""
+
+        lines = ["## Collected Evidence"]
+        if self.executed_capabilities:
+            lines.append("Executed capability packs: " + ", ".join(self.executed_capabilities))
+        if self.pending_capabilities:
+            lines.append(
+                "Capability packs not executed in this runtime: "
+                + ", ".join(self.pending_capabilities)
+            )
+        for item in self.items:
+            lines.append(f"- [{item.capability}] {item.title}: {item.summary}")
+            for detail in item.details[:6]:
+                lines.append(f"  - {detail}")
+        return "\n".join(lines) + "\n"
+
+
+async def collect_capability_evidence(
+    task: str,
+    subagent: str,
+    mode: str | None,
+    capability_plan: CapabilityPlan,
+    *,
+    repo_root: Path | None = None,
+) -> EvidenceBundle:
+    """Collect bounded local evidence for supported capability packs."""
+
+    return await asyncio.to_thread(
+        _collect_capability_evidence_sync,
+        task,
+        subagent,
+        mode,
+        capability_plan,
+        repo_root or Path.cwd(),
+    )
+
+
+def _collect_capability_evidence_sync(
+    task: str,
+    subagent: str,
+    mode: str | None,
+    capability_plan: CapabilityPlan,
+    repo_root: Path,
+) -> EvidenceBundle:
+    bundle = EvidenceBundle()
+    files = _candidate_files(repo_root)
+
+    for capability in capability_plan.required_capabilities:
+        collector = _CAPABILITY_COLLECTORS.get(capability)
+        if collector is None:
+            bundle.pending_capabilities.append(capability)
+            continue
+
+        item = collector(task, subagent, mode, repo_root, files)
+        if item is None:
+            bundle.pending_capabilities.append(capability)
+            continue
+        bundle.executed_capabilities.append(capability)
+        bundle.items.append(item)
+
+    return bundle
+
+
+def _candidate_files(repo_root: Path) -> list[Path]:
+    """Return bounded candidate files for evidence scanning."""
+
+    files: list[Path] = []
+    for dirname in SEARCH_DIRS:
+        base = repo_root / dirname
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in TEXT_EXTENSIONS:
+                continue
+            files.append(path)
+    return files
+
+
+def _collect_repo_analysis(
+    task: str, _subagent: str, _mode: str | None, repo_root: Path, files: list[Path]
+) -> EvidenceItem:
+    """Collect a bounded repository footprint plus task-keyword hits."""
+
+    sample_files = [str(path.relative_to(repo_root)) for path in files[:8]]
+    keywords = _extract_keywords(task)
+    hits = _search_files(files, keywords, repo_root, limit=10) if keywords else []
+
+    summary = (
+        f"Scanned {len(files)} text files under {', '.join(SEARCH_DIRS)}. "
+        f"Task-keyword hits found: {len(hits)}."
+    )
+    details = []
+    if sample_files:
+        details.append("Sample files: " + ", ".join(sample_files))
+    details.extend(hits)
+
+    return EvidenceItem(
+        capability="repo-analysis",
+        title="Repository footprint and task-relevant matches",
+        summary=summary,
+        details=details,
+    )
+
+
+def _collect_planning_assess(
+    task: str, _subagent: str, mode: str | None, repo_root: Path, _files: list[Path]
+) -> EvidenceItem:
+    """Collect planning artifacts and a mode-specific checklist scaffold."""
+
+    planning_artifacts: list[str] = []
+    artifact_candidates = [
+        repo_root / "README.md",
+        repo_root / "ROADMAP.md",
+        repo_root / "docs" / "index.md",
+    ]
+    artifact_candidates.extend(sorted((repo_root / "docs" / "architecture").glob("*.md")))
+
+    for path in artifact_candidates:
+        if path.exists() and path.is_file():
+            planning_artifacts.append(str(path.relative_to(repo_root)))
+
+    if mode == "assess":
+        checklist = [
+            "Define the decision question and success criteria",
+            "Score alternatives against explicit criteria",
+            "Record reversibility, dependencies, and risks",
+            "State conditions or next steps before recommending proceed/reject",
+        ]
+    else:
+        checklist = [
+            "Define objective and measurable success criteria",
+            "Sequence work into phases with dependencies",
+            "Identify blockers, risks, and fallback paths",
+            "Assign deliverables and exit criteria per phase",
+        ]
+
+    summary = (
+        f"Found {len(planning_artifacts)} planning artifact(s) and generated a "
+        f"{mode or 'plan'} checklist scaffold for '{task[:40]}'."
+    )
+    details = []
+    if planning_artifacts:
+        details.append("Planning artifacts: " + ", ".join(planning_artifacts[:6]))
+    details.extend(checklist)
+
+    return EvidenceItem(
+        capability="planning-assess",
+        title="Planning artifacts and checklist scaffold",
+        summary=summary,
+        details=details,
+    )
+
+
+def _collect_security_code_audit(
+    _task: str, _subagent: str, _mode: str | None, repo_root: Path, files: list[Path]
+) -> EvidenceItem:
+    """Collect security-sensitive code hits for code-audit style analysis."""
+
+    hits = _search_files(files, SECURITY_PATTERNS, repo_root, limit=14)
+    summary = (
+        f"Scanned {len(files)} text files for security-sensitive patterns. "
+        f"High-signal hits found: {len(hits)}."
+    )
+
+    details = hits or ["No high-signal security keyword matches found in scanned files."]
+    return EvidenceItem(
+        capability="security-code-audit",
+        title="Security-sensitive code-path matches",
+        summary=summary,
+        details=details,
+    )
+
+
+def _collect_security_audit(
+    _task: str, _subagent: str, _mode: str | None, repo_root: Path, files: list[Path]
+) -> EvidenceItem:
+    """Compatibility collector for the legacy security-audit capability."""
+
+    item = _collect_security_code_audit(_task, _subagent, _mode, repo_root, files)
+    item.capability = "security-audit"
+    item.title = "Security-sensitive repository matches"
+    return item
+
+
+def _collect_red_team_recon(
+    _task: str, _subagent: str, _mode: str | None, repo_root: Path, files: list[Path]
+) -> EvidenceItem:
+    """Collect attack-surface indicators for red-team style analysis."""
+
+    hits = _search_files(files, ATTACK_SURFACE_PATTERNS, repo_root, limit=14)
+    summary = (
+        f"Scanned {len(files)} text files for attack-surface indicators. "
+        f"High-signal hits found: {len(hits)}."
+    )
+    details = hits or ["No obvious attack-surface indicators found in scanned files."]
+    return EvidenceItem(
+        capability="red-team-recon",
+        title="Attack-surface and exposure indicators",
+        summary=summary,
+        details=details,
+    )
+
+
+def _collect_diff_review(
+    _task: str, _subagent: str, _mode: str | None, repo_root: Path, _files: list[Path]
+) -> EvidenceItem | None:
+    """Collect bounded evidence from the current git diff."""
+
+    diff_text = _load_git_diff(repo_root)
+    if not diff_text:
+        return None
+
+    parsed = _parse_unified_diff(diff_text)
+    if not parsed["files"]:
+        return None
+
+    changed_files = parsed["files"][:DIFF_FILE_LIMIT]
+    hunk_summaries = parsed["hunks"][:DIFF_HUNK_LIMIT]
+    test_hints = _infer_test_impact(repo_root, changed_files)
+
+    details: list[str] = []
+    details.append("Changed files: " + ", ".join(changed_files))
+    details.extend(hunk_summaries)
+    details.extend(test_hints)
+
+    summary = (
+        f"Captured {len(changed_files)} changed file(s) and {len(hunk_summaries)} diff hunk summary line(s) "
+        "from the current git diff."
+    )
+    return EvidenceItem(
+        capability="diff-review",
+        title="Changed files and diff-hunk anchors",
+        summary=summary,
+        details=details,
+    )
+
+
+def _collect_docs_research(
+    task: str, _subagent: str, _mode: str | None, _repo_root: Path, _files: list[Path]
+) -> EvidenceItem | None:
+    """Fetch bounded official documentation references inferred from the task."""
+
+    targets = _infer_docs_targets(task)
+    if not targets:
+        return None
+
+    fetched: list[tuple[str, str, str]] = []
+    for url in targets[:DOCS_FETCH_LIMIT]:
+        page = _fetch_docs_page(url)
+        if page is None:
+            continue
+        title, summary = page
+        fetched.append((url, title, summary))
+
+    if not fetched:
+        return None
+
+    details = [f"{title} ({url}): {summary}" for url, title, summary in fetched]
+    summary = (
+        f"Fetched {len(fetched)} official documentation source(s) inferred from the task. "
+        f"Unverified targets skipped: {max(0, len(targets[:DOCS_FETCH_LIMIT]) - len(fetched))}."
+    )
+    return EvidenceItem(
+        capability="docs-research",
+        title="Official documentation references",
+        summary=summary,
+        details=details,
+    )
+
+
+def _extract_keywords(task: str, limit: int = 6) -> list[str]:
+    """Extract a small keyword set from the task."""
+
+    tokens = re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{3,}", task.lower())
+    keywords: list[str] = []
+    for token in tokens:
+        if token in STOPWORDS:
+            continue
+        if token not in keywords:
+            keywords.append(token)
+        if len(keywords) >= limit:
+            break
+    return keywords
+
+
+def _search_files(
+    files: list[Path],
+    patterns: list[str] | tuple[str, ...],
+    repo_root: Path,
+    limit: int,
+) -> list[str]:
+    """Search candidate files for keyword hits and return bounded detail lines."""
+
+    if not patterns:
+        return []
+
+    regex = re.compile("|".join(re.escape(pattern) for pattern in patterns), re.IGNORECASE)
+    hits: list[str] = []
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not regex.search(line):
+                continue
+            snippet = line.strip()
+            if len(snippet) > 120:
+                snippet = snippet[:117] + "..."
+            try:
+                display_path = str(path.relative_to(repo_root))
+            except ValueError:
+                display_path = str(path)
+            hits.append(f"{display_path}:{line_number}: {snippet}")
+            if len(hits) >= limit:
+                return hits
+
+    return hits
+
+
+def _infer_docs_targets(task: str) -> list[str]:
+    """Infer official documentation URLs from task keywords and explicit URLs."""
+
+    lower_task = task.lower()
+    targets: list[str] = []
+
+    for match in re.findall(r"https?://[^\s)>\"']+", task):
+        if match.startswith("https://") and match not in targets:
+            targets.append(match.rstrip(".,);"))
+
+    for keywords, url in DOCS_TARGETS:
+        if any(keyword in lower_task for keyword in keywords) and url not in targets:
+            targets.append(url)
+
+    return targets
+
+
+def _fetch_docs_page(url: str) -> tuple[str, str] | None:
+    """Fetch a documentation page and extract a small grounded summary."""
+
+    try:
+        with httpx.Client(
+            timeout=DOCS_TIMEOUT_SECONDS,
+            follow_redirects=True,
+            headers={"User-Agent": DOCS_USER_AGENT},
+        ) as client:
+            response = client.get(url)
+            response.raise_for_status()
+    except httpx.HTTPError:
+        return None
+
+    content_type = response.headers.get("content-type", "").lower()
+    if not any(token in content_type for token in ("text/html", "text/plain", "application/xhtml+xml")):
+        return None
+
+    return _extract_page_summary(response.text, url)
+
+
+def _load_git_diff(repo_root: Path) -> str:
+    """Load a bounded unified diff for the current repository state."""
+
+    commands = [
+        ["git", "diff", "--no-ext-diff", "--unified=3", "--", "."],
+        ["git", "diff", "--no-ext-diff", "--cached", "--unified=3", "--", "."],
+    ]
+    diff_parts: list[str] = []
+
+    for command in commands:
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=DIFF_FETCH_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+
+        if completed.returncode not in (0, 1):
+            continue
+        stdout = completed.stdout.strip()
+        if stdout:
+            diff_parts.append(stdout)
+
+    if not diff_parts:
+        return ""
+    return "\n".join(diff_parts)
+
+
+def _parse_unified_diff(diff_text: str) -> dict[str, list[str]]:
+    """Parse a minimal summary from unified diff text."""
+
+    files: list[str] = []
+    hunks: list[str] = []
+    current_file: str | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                current_file = parts[3][2:]
+                if current_file not in files:
+                    files.append(current_file)
+            continue
+
+        if line.startswith("@@"):
+            summary = line.strip()
+            if current_file:
+                hunks.append(f"{current_file}: {summary}")
+            else:
+                hunks.append(summary)
+            continue
+
+    return {"files": files, "hunks": hunks}
+
+
+def _infer_test_impact(repo_root: Path, changed_files: list[str]) -> list[str]:
+    """Infer likely test impact from changed files using simple path conventions."""
+
+    hints: list[str] = []
+    for rel_path in changed_files[:DIFF_FILE_LIMIT]:
+        path = Path(rel_path)
+        if path.parts and path.parts[0] == "tests":
+            hints.append(f"Test file changed directly: {rel_path}")
+            continue
+
+        candidate_tests = _candidate_test_paths(path)
+        existing = [candidate for candidate in candidate_tests if (repo_root / candidate).exists()]
+        if existing:
+            hints.append(f"Likely impacted tests for {rel_path}: {', '.join(existing[:2])}")
+
+    return hints[:6]
+
+
+def _candidate_test_paths(path: Path) -> list[str]:
+    """Generate likely test file paths for a changed source file."""
+
+    candidates: list[str] = []
+    if not path.suffix:
+        return candidates
+
+    stem = path.stem
+    suffix = path.suffix
+    file_name = path.name
+
+    candidates.append(str(Path("tests") / f"test_{stem}{suffix}"))
+    candidates.append(str(Path("tests") / file_name))
+
+    if path.parts and path.parts[0] == "src":
+        relative = Path(*path.parts[1:])
+        candidates.append(str(Path("tests") / relative.parent / f"test_{relative.stem}{suffix}"))
+        candidates.append(str(Path("tests") / relative.parent / relative.name))
+
+    deduped: list[str] = []
+    for candidate in candidates:
+        if candidate not in deduped:
+            deduped.append(candidate)
+    return deduped
+
+
+def _extract_page_summary(content: str, fallback_url: str) -> tuple[str, str]:
+    """Extract a short title and summary from HTML or plain-text docs content."""
+
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", content, re.IGNORECASE | re.DOTALL)
+    if title_match:
+        title = _clean_text(title_match.group(1))
+    else:
+        heading_match = re.search(r"^\s*#\s+(.+)$", content, re.MULTILINE)
+        title = _clean_text(heading_match.group(1)) if heading_match else fallback_url
+
+    meta_match = re.search(
+        r'<meta[^>]+name=["\']description["\'][^>]+content=["\'](.*?)["\']',
+        content,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if meta_match:
+        summary = _clean_text(meta_match.group(1))
+    else:
+        text_content = _clean_text(re.sub(r"<[^>]+>", " ", content))
+        summary = text_content[:200].rsplit(" ", 1)[0] if len(text_content) > 200 else text_content
+
+    return title or fallback_url, summary or "Documentation page fetched with no extractable summary."
+
+
+def _clean_text(value: str) -> str:
+    """Normalize HTML/plain-text content into a single compact line."""
+
+    normalized = html.unescape(value)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip()
+
+
+_CAPABILITY_COLLECTORS: dict[str, Any] = {
+    "repo-analysis": _collect_repo_analysis,
+    "planning-assess": _collect_planning_assess,
+    "security-audit": _collect_security_audit,
+    "security-code-audit": _collect_security_code_audit,
+    "red-team-recon": _collect_red_team_recon,
+    "docs-research": _collect_docs_research,
+    "diff-review": _collect_diff_review,
+}
+
+
+__all__ = ["EvidenceBundle", "EvidenceItem", "collect_capability_evidence"]

--- a/src/llm_council/engine/orchestrator.py
+++ b/src/llm_council/engine/orchestrator.py
@@ -29,21 +29,39 @@ from jsonschema import Draft7Validator
 from pydantic import BaseModel, ConfigDict, Field
 
 from llm_council.config.models import get_council_models, is_multi_model_enabled
+from llm_council.engine.capabilities import CapabilityPlan, select_capability_plan
 from llm_council.engine.degradation import DegradationAction, DegradationPolicy
+from llm_council.engine.evidence import EvidenceBundle, collect_capability_evidence
 from llm_council.engine.health import HealthReport, preflight_check
-from llm_council.protocol.types import PhaseTiming, SummaryTier
+from llm_council.protocol.types import (
+    PhaseTiming,
+    ReasoningProfile,
+    RuntimeProfile,
+    SummaryTier,
+)
 from llm_council.providers.base import (
     DoctorResult,
     GenerateRequest,
     GenerateResponse,
     Message,
     ProviderAdapter,
+    ReasoningConfig,
     StructuredOutputConfig,
 )
 from llm_council.providers.registry import get_registry
 from llm_council.schemas import load_schema
 from llm_council.storage.artifacts import ArtifactStore, ArtifactType, get_store
-from llm_council.subagents import load_subagent
+from llm_council.subagents import (
+    get_effective_schema,
+    get_effective_system_prompt,
+    get_model_for_subagent,
+    get_model_overrides,
+    get_model_pack,
+    get_provider_preferences,
+    get_reasoning_budget,
+    load_subagent,
+    resolve_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +122,53 @@ class OrchestratorConfig(BaseModel):
             "Used for --context/--system file injection."
         ),
     )
+    mode: str | None = Field(
+        default=None,
+        description="Subagent mode override (e.g. review/security, plan/assess).",
+    )
+    temperature: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=2.0,
+        description="Global temperature override applied to all council phases.",
+    )
+    max_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Global max_tokens override applied to all council phases.",
+    )
+    runtime_profile: RuntimeProfile = Field(
+        default=RuntimeProfile.DEFAULT,
+        description="High-level runtime budget override (default/bounded).",
+    )
+    reasoning_profile: ReasoningProfile = Field(
+        default=ReasoningProfile.DEFAULT,
+        description="High-level override for reasoning intensity (default/off/light).",
+    )
+    output_schema: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional custom output schema override for the run.",
+    )
+    model_pack: str | None = Field(
+        default=None,
+        description="Optional runtime model-pack override for provider/model resolution.",
+    )
+    execution_profile: str | None = Field(
+        default=None,
+        description="Optional runtime execution-profile override.",
+    )
+    budget_class: str | None = Field(
+        default=None,
+        description="Optional runtime budget-class override.",
+    )
+    required_capabilities: list[str] = Field(
+        default_factory=list,
+        description="Optional runtime capability overrides merged into the resolved plan.",
+    )
+    disable_local_evidence: bool = Field(
+        default=False,
+        description="Disable local evidence collection and rely only on provided context.",
+    )
 
 
 class CostEstimate(BaseModel):
@@ -144,6 +209,22 @@ class CouncilResult(BaseModel):
     degradation_report: dict[str, Any] | None = Field(
         default=None, description="Degradation events during execution."
     )
+    execution_plan: dict[str, Any] | None = Field(
+        default=None,
+        description="Resolved runtime plan (mode, schema, providers, reasoning, overrides).",
+    )
+    routed: bool = Field(
+        default=False,
+        description="Whether the result came from a router-followed execution.",
+    )
+    routing_decision: dict[str, Any] | None = Field(
+        default=None,
+        description="Router output used to select the routed subagent and mode.",
+    )
+    routing_execution_plan: dict[str, Any] | None = Field(
+        default=None,
+        description="Execution plan from the router run before follow-up execution.",
+    )
 
 
 class ValidationResult(BaseModel):
@@ -161,7 +242,8 @@ class Orchestrator:
     """Coordinates multi-LLM council runs using provider adapters."""
 
     def __init__(self, providers: list[str], config: OrchestratorConfig) -> None:
-        self._provider_names = providers
+        self._configured_provider_names = list(providers)
+        self._provider_names = list(providers)
         self._config = config
         self._registry = get_registry()
         self._providers: dict[str, ProviderAdapter] = {}
@@ -174,6 +256,17 @@ class Orchestrator:
         self._subagent_name: str | None = None
         self._subagent_config: dict[str, Any] | None = None
         self._schema: dict[str, Any] | None = None
+        self._schema_name: str | None = None
+        self._schema_source: str | None = None
+        self._resolved_mode: str | None = None
+        self._system_prompt: str = ""
+        self._reasoning: ReasoningConfig | None = None
+        self._capability_plan: CapabilityPlan | None = None
+        self._evidence_bundle: EvidenceBundle | None = None
+        self._resolved_model_pack: str | None = None
+        self._model_pack_source: str | None = None
+        self._resolved_model_overrides: dict[str, str] = {}
+        self._execution_plan: dict[str, Any] | None = None
         self._artifact_store: ArtifactStore | None = None
         self._degradation_policy: DegradationPolicy | None = None
         self._health_report: HealthReport | None = None
@@ -184,7 +277,7 @@ class Orchestrator:
 
         if self._config.enable_graceful_degradation:
             self._degradation_policy = DegradationPolicy(
-                max_retries=2,
+                max_retries=self._provider_retry_budget(),
                 min_providers_required=1,
                 abort_on_all_failures=True,
             )
@@ -197,13 +290,15 @@ class Orchestrator:
         self._output_tokens = {}
         self._task = task
         self._subagent_name = subagent
+        self._health_report = None
+        self._run_id = None
+        self._execution_plan = None
+        self._evidence_bundle = None
         phase_timings: list[PhaseTiming] = []
         start_time = time.monotonic()
 
         try:
-            self._subagent_config = load_subagent(subagent)
-            schema_name = self._subagent_config.get("schema")
-            self._schema = load_schema(schema_name) if schema_name else None
+            self._prepare_run(subagent)
         except Exception as exc:
             duration_ms = int((time.monotonic() - start_time) * 1000)
             return CouncilResult(
@@ -213,6 +308,7 @@ class Orchestrator:
                 phase_timings=phase_timings or None,
                 provider_errors=dict(self._provider_init_errors) or None,
                 cost_estimate=self._build_cost_estimate(),
+                execution_plan=self._execution_plan,
             )
 
         provider_errors = self._validate_providers_for_run()
@@ -225,10 +321,8 @@ class Orchestrator:
                 phase_timings=phase_timings or None,
                 provider_errors=provider_errors,
                 cost_estimate=self._build_cost_estimate(),
+                execution_plan=self._execution_plan,
             )
-
-        # Refresh provider adapters for this run in case registry changed.
-        self._initialize_providers()
 
         # Initialize degradation policy for this run
         if self._degradation_policy:
@@ -243,23 +337,11 @@ class Orchestrator:
             )
             self._run_id = run_record.run_id
 
-        # Run preflight health checks if enabled
-        if self._config.enable_health_check and self._providers:
+        if self._providers:
             try:
-                usable_providers, health_report = await preflight_check(
-                    self._providers,
-                    timeout=10.0,
-                    skip_on_failure=True,
-                )
-                self._health_report = health_report
-                self._providers = usable_providers
-                logger.info(
-                    "Health check: %d/%d providers usable",
-                    health_report.usable_count,
-                    health_report.total_count,
-                )
+                await self._ensure_usable_providers()
             except Exception as exc:
-                logger.warning("Health check failed: %s", exc)
+                logger.warning("Provider health resolution failed: %s", exc)
 
         if not self._providers:
             duration_ms = int((time.monotonic() - start_time) * 1000)
@@ -270,9 +352,32 @@ class Orchestrator:
                 phase_timings=phase_timings or None,
                 provider_errors=dict(self._provider_init_errors) or None,
                 cost_estimate=self._build_cost_estimate(),
+                execution_plan=self._execution_plan,
             )
 
+        drafts: dict[str, str] = {}
+        critique = ""
+        synthesis_result = ValidationResult(ok=False, errors=["Synthesis did not run."])
+        synth_attempts = 0
+
         try:
+            if self._capability_plan and self._capability_plan.required_capabilities:
+                evidence_bundle, evidence_timing = await self._timed(
+                    self._collect_evidence_for_run, "evidence"
+                )
+                self._evidence_bundle = evidence_bundle
+                phase_timings.append(evidence_timing)
+
+                if self._artifact_store and self._run_id and evidence_bundle.items:
+                    try:
+                        self._artifact_store.store_artifact(
+                            run_id=self._run_id,
+                            content=evidence_bundle.to_prompt_block(),
+                            artifact_type=ArtifactType.TOOL_LOG,
+                        )
+                    except Exception as exc:
+                        logger.debug("Failed to store evidence artifact: %s", exc)
+
             drafts, draft_timing = await self._timed(self._run_parallel_drafts, "drafts")
             phase_timings.append(draft_timing)
 
@@ -288,39 +393,6 @@ class Orchestrator:
                             )
                         except Exception as exc:
                             logger.debug("Failed to store draft artifact: %s", exc)
-
-            critique, critique_timing = await self._timed(
-                lambda: self._run_critique(drafts), "critique"
-            )
-            phase_timings.append(critique_timing)
-
-            # Store critique as artifact if enabled
-            if self._artifact_store and self._run_id and critique:
-                try:
-                    self._artifact_store.store_artifact(
-                        run_id=self._run_id,
-                        content=critique,
-                        artifact_type=ArtifactType.CRITIQUE,
-                    )
-                except Exception as exc:
-                    logger.debug("Failed to store critique artifact: %s", exc)
-
-            synth_result, synth_timing = await self._timed(
-                lambda: self._run_synthesis(drafts, critique), "synthesis"
-            )
-            synthesis_result, synth_attempts = synth_result
-            phase_timings.append(synth_timing)
-
-            # Store synthesis as artifact if enabled
-            if self._artifact_store and self._run_id and synthesis_result.raw:
-                try:
-                    self._artifact_store.store_artifact(
-                        run_id=self._run_id,
-                        content=synthesis_result.raw,
-                        artifact_type=ArtifactType.SYNTHESIS,
-                    )
-                except Exception as exc:
-                    logger.debug("Failed to store synthesis artifact: %s", exc)
         except Exception as exc:
             duration_ms = int((time.monotonic() - start_time) * 1000)
             logger.exception("Council run failed.")
@@ -334,7 +406,49 @@ class Orchestrator:
                 phase_timings=phase_timings or None,
                 provider_errors=dict(self._provider_init_errors) or None,
                 cost_estimate=self._build_cost_estimate(),
+                execution_plan=self._execution_plan,
             )
+
+        try:
+            critique, critique_timing = await self._timed(lambda: self._run_critique(drafts), "critique")
+            phase_timings.append(critique_timing)
+
+            # Store critique as artifact if enabled
+            if self._artifact_store and self._run_id and critique:
+                try:
+                    self._artifact_store.store_artifact(
+                        run_id=self._run_id,
+                        content=critique,
+                        artifact_type=ArtifactType.CRITIQUE,
+                    )
+                except Exception as exc:
+                    logger.debug("Failed to store critique artifact: %s", exc)
+        except Exception as exc:
+            detail = self._format_exception_chain(exc)
+            critique = ""
+            self._append_degradation_note(f"Critique failed ({detail}); continuing without critique.")
+            logger.warning("Critique phase failed; continuing without critique: %s", detail)
+
+        try:
+            synth_result, synth_timing = await self._timed(
+                lambda: self._run_synthesis(drafts, critique), "synthesis"
+            )
+            synthesis_result, synth_attempts = synth_result
+            phase_timings.append(synth_timing)
+        except Exception as exc:
+            logger.warning("Synthesis phase failed; attempting draft fallback: %s", exc)
+            synthesis_result, synth_attempts = self._fallback_synthesis_from_drafts(drafts, exc)
+
+        # Store synthesis as artifact if enabled
+        if self._artifact_store and self._run_id and synthesis_result.raw:
+            try:
+                self._artifact_store.store_artifact(
+                    run_id=self._run_id,
+                    content=synthesis_result.raw,
+                    artifact_type=ArtifactType.SYNTHESIS,
+                )
+            except Exception as exc:
+                logger.debug("Failed to store synthesis artifact: %s", exc)
 
         duration_ms = int((time.monotonic() - start_time) * 1000)
 
@@ -372,6 +486,7 @@ class Orchestrator:
             run_id=self._run_id,
             health_report=health_report_dict,
             degradation_report=degradation_report_dict,
+            execution_plan=self._execution_plan,
         )
 
     async def _run_parallel_drafts(self) -> dict[str, str]:
@@ -390,7 +505,7 @@ class Orchestrator:
         drafts: dict[str, str] = {}
         for provider_name, result in zip(self._providers.keys(), results, strict=True):
             if isinstance(result, BaseException):
-                error_msg = str(result)
+                error_msg = self._format_exception_chain(result)
                 self._provider_init_errors[provider_name] = error_msg
 
                 # Use degradation policy to decide action
@@ -413,30 +528,65 @@ class Orchestrator:
 
         return drafts
 
+    def _format_exception_chain(self, error: BaseException) -> str:
+        """Render an exception with its direct cause chain for diagnostics."""
+
+        parts = [str(error)]
+        current = error.__cause__ or error.__context__
+        while current is not None:
+            text = str(current)
+            if text:
+                parts.append(f"caused by: {text}")
+            current = current.__cause__ or current.__context__
+        return " | ".join(part for part in parts if part)
+
     async def _run_critique(self, drafts: dict[str, str]) -> str:
         """Run an adversarial critique over the drafts."""
 
         if self._task is None or self._subagent_config is None:
             raise RuntimeError("Orchestrator.run must be called before critique.")
 
-        provider_name, adapter = await self._select_provider_for_phase("critique")
+        candidates = await self._candidate_providers_for_phase("critique")
+        self._record_phase_provider_candidates("critique", [name for name, _adapter in candidates])
+        if not candidates:
+            raise RuntimeError("No healthy providers available for critique.")
+
         system_prompt = (
             "You are an adversarial reviewer. Identify errors, gaps, contradictions, "
             "and schema violations. Provide concrete fixes."
         )
         user_prompt = self._format_critique_prompt(self._task, drafts)
+        last_error: Exception | None = None
 
-        request = GenerateRequest(
-            model=self._model_override(provider_name),
-            messages=[
-                Message(role="system", content=system_prompt),
-                Message(role="user", content=user_prompt),
-            ],
-            max_tokens=self._config.max_critique_tokens,
-            temperature=self._config.critique_temperature,
-        )
-        response = await self._call_provider(provider_name, adapter, request)
-        return response.text or ""
+        for index, (provider_name, adapter) in enumerate(candidates):
+            request = GenerateRequest(
+                model=self._model_override(provider_name),
+                messages=[
+                    Message(role="system", content=system_prompt),
+                    Message(role="user", content=user_prompt),
+                ],
+                timeout_seconds=self._provider_request_timeout_seconds("critique"),
+                max_tokens=self._phase_max_tokens(self._config.max_critique_tokens, phase="critique"),
+                temperature=self._phase_temperature(self._config.critique_temperature),
+                reasoning=self._reasoning,
+            )
+            try:
+                response = await self._call_provider(
+                    provider_name,
+                    adapter,
+                    request,
+                    remaining_providers=max(len(candidates) - index - 1, 0),
+                )
+            except Exception as exc:
+                last_error = exc
+                continue
+
+            self._record_phase_provider_used("critique", provider_name)
+            return response.text or ""
+
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("Critique failed without a usable provider response.")
 
     async def _run_synthesis(
         self, drafts: dict[str, str], critique: str
@@ -446,51 +596,77 @@ class Orchestrator:
         if self._task is None or self._subagent_config is None:
             raise RuntimeError("Orchestrator.run must be called before synthesis.")
 
-        provider_name, adapter = await self._select_provider_for_phase("synthesis")
+        candidates = await self._candidate_providers_for_phase("synthesis")
+        self._record_phase_provider_candidates("synthesis", [name for name, _adapter in candidates])
+        if not candidates:
+            raise RuntimeError("No healthy providers available for synthesis.")
+
         schema = self._schema
         errors: list[str] = []
         last_raw: str | None = None
+        total_attempts = 0
+        last_error: Exception | None = None
 
-        for attempt in range(1, self._config.max_retries + 1):
-            system_prompt = (
-                "You are the synthesizer. Combine drafts and critique into a single response. "
-                "Return ONLY valid JSON that matches the provided schema."
-            )
-            user_prompt = self._format_synthesis_prompt(
-                task=self._task,
-                drafts=drafts,
-                critique=critique,
-                schema=schema,
-                errors=errors,
-            )
-
-            request = GenerateRequest(
-                model=self._model_override(provider_name),
-                messages=[
-                    Message(role="system", content=system_prompt),
-                    Message(role="user", content=user_prompt),
-                ],
-                max_tokens=self._config.max_synthesis_tokens,
-                temperature=self._config.synthesis_temperature,
-            )
-
-            if schema and await adapter.supports("structured_output"):
-                # Use StructuredOutputConfig for provider-agnostic structured output
-                # Each provider transforms this to their native API format
-                request.structured_output = StructuredOutputConfig(
-                    json_schema=schema,
-                    name=self._subagent_name or "council_output",
-                    strict=True,
+        for provider_index, (provider_name, adapter) in enumerate(candidates):
+            for _attempt in range(1, self._config.max_retries + 1):
+                total_attempts += 1
+                system_prompt = (
+                    "You are the synthesizer. Combine drafts and critique into a single response. "
+                    "Return ONLY valid JSON that matches the provided schema."
+                )
+                user_prompt = self._format_synthesis_prompt(
+                    task=self._task,
+                    drafts=drafts,
+                    critique=critique,
+                    schema=schema,
+                    errors=errors,
                 )
 
-            response = await self._call_provider(provider_name, adapter, request)
-            last_raw = response.text or ""
-            result = self._validate_response(last_raw)
-            if result.ok:
-                return result, attempt
-            errors = result.errors
+                request = GenerateRequest(
+                    model=self._model_override(provider_name),
+                    messages=[
+                        Message(role="system", content=system_prompt),
+                        Message(role="user", content=user_prompt),
+                    ],
+                    timeout_seconds=self._provider_request_timeout_seconds("synthesis"),
+                    max_tokens=self._phase_max_tokens(
+                        self._config.max_synthesis_tokens,
+                        phase="synthesis",
+                    ),
+                    temperature=self._phase_temperature(self._config.synthesis_temperature),
+                    reasoning=self._reasoning,
+                )
 
-        return ValidationResult(ok=False, errors=errors, raw=last_raw), self._config.max_retries
+                if schema and await adapter.supports("structured_output"):
+                    request.structured_output = StructuredOutputConfig(
+                        json_schema=schema,
+                        name=self._subagent_name or "council_output",
+                        strict=True,
+                    )
+
+                try:
+                    response = await self._call_provider(
+                        provider_name,
+                        adapter,
+                        request,
+                        remaining_providers=max(len(candidates) - provider_index - 1, 0),
+                    )
+                except Exception as exc:
+                    last_error = exc
+                    break
+
+                last_raw = response.text or ""
+                result = self._validate_response(last_raw)
+                if result.ok:
+                    self._record_phase_provider_used("synthesis", provider_name)
+                    return result, total_attempts
+                errors = result.errors
+
+        if last_raw is not None:
+            return ValidationResult(ok=False, errors=errors, raw=last_raw), total_attempts
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("Synthesis failed without a usable provider response.")
 
     async def _generate_draft(
         self, provider_name: str, adapter: ProviderAdapter
@@ -500,7 +676,7 @@ class Orchestrator:
         if self._task is None or self._subagent_config is None:
             raise RuntimeError("Orchestrator.run must be called before drafting.")
 
-        system_prompt = self._subagent_config.get("prompts", {}).get("system", "")
+        system_prompt = self._system_prompt
         user_prompt = self._format_draft_prompt(self._task)
 
         request = GenerateRequest(
@@ -509,14 +685,21 @@ class Orchestrator:
                 Message(role="system", content=system_prompt),
                 Message(role="user", content=user_prompt),
             ],
-            max_tokens=self._config.max_draft_tokens,
-            temperature=self._config.draft_temperature,
+            timeout_seconds=self._provider_request_timeout_seconds("draft"),
+            max_tokens=self._phase_max_tokens(self._config.max_draft_tokens, phase="draft"),
+            temperature=self._phase_temperature(self._config.draft_temperature),
+            reasoning=self._reasoning,
         )
         response = await self._call_provider(provider_name, adapter, request)
         return provider_name, response.text or ""
 
     async def _call_provider(
-        self, provider_name: str, adapter: ProviderAdapter, request: GenerateRequest
+        self,
+        provider_name: str,
+        adapter: ProviderAdapter,
+        request: GenerateRequest,
+        *,
+        remaining_providers: int | None = None,
     ) -> GenerateResponse:
         """Execute a provider request with timeout and usage tracking."""
 
@@ -530,36 +713,523 @@ class Orchestrator:
                     usage = dict(chunk.usage)
             return GenerateResponse(text="".join(text_parts), usage=usage)
 
-        try:
-            result = await asyncio.wait_for(adapter.generate(request), timeout=self._config.timeout)
-            if isinstance(result, GenerateResponse):
-                response = result
-            else:
-                response = await asyncio.wait_for(
-                    _consume_stream(result), timeout=self._config.timeout
-                )
+        while True:
+            try:
+                result = await asyncio.wait_for(adapter.generate(request), timeout=self._config.timeout)
+                if isinstance(result, GenerateResponse):
+                    response = result
+                else:
+                    response = await asyncio.wait_for(
+                        _consume_stream(result), timeout=self._config.timeout
+                    )
 
-            self._record_usage(provider_name, response.usage)
-            return response
+                self._record_usage(provider_name, response.usage)
+                return response
 
-        except Exception as exc:
-            # Let degradation policy decide if this should be handled
-            if self._degradation_policy:
-                remaining = len(self._providers) - len(self._provider_init_errors) - 1
-                decision = self._degradation_policy.decide(
-                    provider=provider_name,
-                    error=exc,
-                    phase="call",
-                    remaining_providers=remaining,
-                )
+            except Exception as exc:
+                error_detail = self._format_exception_chain(exc)
+                if self._degradation_policy:
+                    remaining = (
+                        remaining_providers
+                        if remaining_providers is not None
+                        else len(self._providers) - len(self._provider_init_errors) - 1
+                    )
+                    decision = self._degradation_policy.decide(
+                        provider=provider_name,
+                        error=exc,
+                        phase="call",
+                        remaining_providers=remaining,
+                    )
 
-                if decision.action == DegradationAction.ABORT:
-                    raise RuntimeError(f"Provider call aborted: {decision.reason}") from exc
-                elif decision.action == DegradationAction.RETRY and decision.retry_delay_ms > 0:
-                    await asyncio.sleep(decision.retry_delay_ms / 1000.0)
+                    if decision.action == DegradationAction.ABORT:
+                        self._provider_init_errors[provider_name] = (
+                            f"{error_detail} | degraded: {decision.reason}"
+                        )
+                        raise RuntimeError(f"Provider call aborted: {decision.reason}") from exc
+                    if decision.action == DegradationAction.RETRY:
+                        if decision.retry_delay_ms > 0:
+                            await asyncio.sleep(decision.retry_delay_ms / 1000.0)
+                        continue
 
-            # Re-raise the exception to let caller handle it
-            raise
+                self._provider_init_errors[provider_name] = error_detail
+                raise
+
+    def _prepare_run(self, subagent: str) -> None:
+        """Resolve subagent mode, schema, providers, and runtime overrides for a run."""
+
+        self._subagent_config = load_subagent(subagent)
+        self._resolved_mode = resolve_mode(self._subagent_config, self._config.mode)
+        self._capability_plan = select_capability_plan(
+            subagent,
+            self._resolved_mode,
+            subagent_config=self._subagent_config,
+            requested_execution_profile=self._config.execution_profile,
+            requested_budget_class=self._config.budget_class,
+            requested_capabilities=self._config.required_capabilities,
+        )
+        self._system_prompt = get_effective_system_prompt(self._subagent_config, self._resolved_mode)
+        if self._config.model_pack:
+            self._resolved_model_pack = self._config.model_pack
+            self._model_pack_source = "config"
+        else:
+            self._resolved_model_pack = get_model_pack(
+                self._subagent_config,
+                self._resolved_mode,
+            ).value
+            self._model_pack_source = "subagent"
+
+        if self._config.output_schema is not None:
+            self._schema = self._config.output_schema
+            self._schema_name = "custom"
+            self._schema_source = "custom"
+        else:
+            self._schema_name = get_effective_schema(self._subagent_config, self._resolved_mode)
+            self._schema_source = "subagent"
+            self._schema = load_schema(self._schema_name) if self._schema_name else None
+
+        reasoning_budget = get_reasoning_budget(self._subagent_config, self._resolved_mode)
+        self._reasoning = self._build_reasoning_config(reasoning_budget)
+
+        provider_preferences = get_provider_preferences(self._subagent_config, self._resolved_mode)
+        self._provider_names = self._resolve_provider_names_for_run(provider_preferences)
+        self._initialize_providers()
+
+        self._resolved_model_overrides = self._resolve_model_overrides()
+        self._execution_plan = {
+            "subagent": subagent,
+            "mode": self._resolved_mode,
+            "schema_name": self._schema_name,
+            "schema_source": self._schema_source,
+            "model_pack": self._resolved_model_pack,
+            "model_pack_source": self._model_pack_source,
+            "providers": list(self._provider_names),
+            "system_prompt_configured": bool(self._system_prompt.strip()),
+            "temperature_override": self._config.temperature,
+            "max_tokens_override": self._config.max_tokens,
+            "runtime_profile": self._config.runtime_profile.value,
+            "reasoning_profile": self._config.reasoning_profile.value,
+            "provider_retry_budget": self._provider_retry_budget(),
+            "phase_token_budgets": {
+                "draft": self._phase_max_tokens(self._config.max_draft_tokens, phase="draft"),
+                "critique": self._phase_max_tokens(
+                    self._config.max_critique_tokens,
+                    phase="critique",
+                ),
+                "synthesis": self._phase_max_tokens(
+                    self._config.max_synthesis_tokens,
+                    phase="synthesis",
+                ),
+            },
+            "provider_request_timeouts": {
+                "draft": self._provider_request_timeout_seconds("draft"),
+                "critique": self._provider_request_timeout_seconds("critique"),
+                "synthesis": self._provider_request_timeout_seconds("synthesis"),
+            },
+            "model_overrides": dict(self._resolved_model_overrides),
+            "reasoning": self._reasoning.model_dump(exclude_none=True) if self._reasoning else None,
+            "execution_profile": (
+                self._capability_plan.execution_profile if self._capability_plan else "prompt_only"
+            ),
+            "budget_class": self._capability_plan.budget_class if self._capability_plan else "normal",
+            "required_capabilities": (
+                list(self._capability_plan.required_capabilities) if self._capability_plan else []
+            ),
+            "registered_tools": list(self._capability_plan.tool_names) if self._capability_plan else [],
+            "evidence_requirements": (
+                list(self._capability_plan.evidence_requirements) if self._capability_plan else []
+            ),
+            "local_evidence_disabled": self._config.disable_local_evidence,
+            "executed_capabilities": [],
+            "pending_capabilities": (
+                list(self._capability_plan.required_capabilities) if self._capability_plan else []
+            ),
+            "evidence_items": 0,
+        }
+
+    def _build_reasoning_config(self, budget: Any) -> ReasoningConfig | None:
+        """Convert a reasoning budget config into a provider-agnostic request config."""
+
+        profile = self._config.reasoning_profile
+        if profile == ReasoningProfile.OFF:
+            return None
+
+        if budget is None or not budget.enabled:
+            return None
+
+        effort = budget.effort
+        budget_tokens = budget.budget_tokens
+        thinking_level = budget.thinking_level
+
+        if profile == ReasoningProfile.LIGHT:
+            if effort not in (None, "none"):
+                effort = "low"
+            if budget_tokens is not None:
+                budget_tokens = min(budget_tokens, 4096)
+            if thinking_level not in (None, "minimal", "low"):
+                thinking_level = "low"
+
+        return ReasoningConfig(
+            enabled=True,
+            effort=effort,
+            budget_tokens=budget_tokens,
+            thinking_level=thinking_level,
+        )
+
+    def _resolve_provider_names_for_run(self, provider_preferences: Any) -> list[str]:
+        """Resolve the provider list that should actually execute this run."""
+
+        candidates = self._candidate_provider_names()
+        if provider_preferences is None:
+            return candidates
+
+        excluded = set(provider_preferences.exclude)
+        candidates = [
+            provider_name
+            for provider_name in candidates
+            if self._provider_identity(provider_name) not in excluded
+        ]
+
+        preferred = self._match_provider_preferences(candidates, provider_preferences.preferred)
+        if preferred:
+            return preferred
+
+        fallback = self._match_provider_preferences(candidates, provider_preferences.fallback)
+        if fallback:
+            return fallback
+
+        return candidates
+
+    def _candidate_provider_names(self) -> list[str]:
+        """Return configured provider names after model expansion, before filtering."""
+
+        models = self._config.models
+        if models is None and is_multi_model_enabled():
+            models = get_council_models()
+
+        if models and len(models) > 1 and self._configured_provider_names == ["openrouter"]:
+            return list(models)
+
+        return list(self._configured_provider_names)
+
+    def _match_provider_preferences(
+        self, candidates: list[str], preferences: list[str]
+    ) -> list[str]:
+        """Return candidates that match a preference list, preserving preference order."""
+
+        matched: list[str] = []
+        seen: set[str] = set()
+        for preferred_provider in preferences:
+            for provider_name in candidates:
+                if provider_name in seen:
+                    continue
+                if self._provider_identity(provider_name) == preferred_provider:
+                    matched.append(provider_name)
+                    seen.add(provider_name)
+        return matched
+
+    async def _ensure_usable_providers(self) -> None:
+        """Run health checks when needed and auto-fallback from dead defaults."""
+
+        if not self._providers:
+            return
+
+        should_health_check = self._config.enable_health_check or self._should_attempt_provider_auto_fallback()
+        if not should_health_check:
+            return
+
+        usable_providers, health_report = await preflight_check(
+            self._providers,
+            timeout=10.0,
+            skip_on_failure=True,
+        )
+        self._health_report = health_report
+
+        if usable_providers:
+            self._apply_provider_resolution(usable_providers)
+            logger.info(
+                "Health check: %d/%d providers usable",
+                health_report.usable_count,
+                health_report.total_count,
+            )
+            return
+
+        if not self._should_attempt_provider_auto_fallback():
+            self._providers = {}
+            return
+
+        fallback_names = self._fallback_provider_candidates()
+        fallback_providers, fallback_errors = self._instantiate_providers(fallback_names)
+        self._provider_init_errors.update(fallback_errors)
+        if not fallback_providers:
+            self._providers = {}
+            return
+
+        fallback_usable, fallback_report = await preflight_check(
+            fallback_providers,
+            timeout=10.0,
+            skip_on_failure=True,
+        )
+        if not fallback_usable:
+            self._health_report = fallback_report
+            self._providers = {}
+            return
+
+        self._health_report = fallback_report
+        self._apply_provider_resolution(
+            fallback_usable,
+            auto_fallback_from=list(self._provider_names),
+        )
+        logger.info(
+            "Provider auto-fallback selected %s",
+            ", ".join(self._provider_names),
+        )
+
+    def _should_attempt_provider_auto_fallback(self) -> bool:
+        """Return True when dead default providers should fall back to configured direct providers."""
+
+        return self._provider_names == ["openrouter"] and bool(self._fallback_provider_candidates())
+
+    def _fallback_provider_candidates(self) -> list[str]:
+        """Return direct provider names from user config that can replace the dead default path."""
+
+        candidates: list[str] = []
+        for name in self._config.provider_configs:
+            identity = self._provider_identity(name)
+            if identity == "openrouter":
+                continue
+            if name not in candidates:
+                candidates.append(name)
+        return candidates
+
+    def _apply_provider_resolution(
+        self,
+        providers: dict[str, ProviderAdapter],
+        *,
+        auto_fallback_from: list[str] | None = None,
+    ) -> None:
+        """Adopt a resolved provider set and recompute model overrides."""
+
+        self._providers = providers
+        self._provider_names = list(providers.keys())
+        self._resolved_model_overrides = self._resolve_model_overrides()
+
+        if self._execution_plan is not None:
+            self._execution_plan["providers"] = list(self._provider_names)
+            self._execution_plan["model_overrides"] = dict(self._resolved_model_overrides)
+            if auto_fallback_from:
+                self._execution_plan["provider_auto_fallback"] = {
+                    "from": list(auto_fallback_from),
+                    "to": list(self._provider_names),
+                }
+
+    def _instantiate_providers(
+        self, provider_names: list[str]
+    ) -> tuple[dict[str, ProviderAdapter], dict[str, str]]:
+        """Instantiate a set of providers without mutating run state."""
+
+        from llm_council.providers.openrouter import create_openrouter_for_model
+
+        providers: dict[str, ProviderAdapter] = {}
+        init_errors: dict[str, str] = {}
+        for name in provider_names:
+            try:
+                if "/" in name and name != "openrouter":
+                    providers[name] = create_openrouter_for_model(name)
+                    continue
+                kwargs = self._config.provider_configs.get(name, {})
+                providers[name] = self._registry.get_provider(name, **kwargs)
+            except Exception as exc:
+                init_errors[name] = str(exc)
+        return providers, init_errors
+
+    def _provider_identity(self, provider_name: str) -> str:
+        """Map a provider or virtual provider name to its canonical identity."""
+
+        if "/" in provider_name and provider_name != "openrouter":
+            return provider_name.split("/", 1)[0]
+        return provider_name
+
+    def _resolve_model_overrides(self) -> dict[str, str]:
+        """Resolve effective model overrides for the active provider set."""
+
+        overrides = dict(self._config.model_overrides)
+        subagent_overrides = get_model_overrides(self._subagent_config or {}, self._resolved_mode)
+        subagent_data = (
+            subagent_overrides.model_dump(exclude_none=True) if subagent_overrides else {}
+        )
+
+        for provider_name in self._provider_names:
+            if "/" in provider_name and provider_name != "openrouter":
+                continue
+
+            identity = self._provider_identity(provider_name)
+            if provider_name in overrides:
+                continue
+            if identity in overrides:
+                overrides[provider_name] = overrides[identity]
+                continue
+            explicit_default_model = self._configured_default_model_for_provider(provider_name)
+            if explicit_default_model:
+                overrides[provider_name] = explicit_default_model
+                continue
+            if self._config.model_pack is not None:
+                default_model = self._default_model_for_provider(identity)
+                if default_model:
+                    overrides[provider_name] = default_model
+                    continue
+            if identity in subagent_data:
+                overrides[provider_name] = subagent_data[identity]
+                continue
+
+            default_model = self._default_model_for_provider(identity)
+            if default_model:
+                overrides[provider_name] = default_model
+
+        return overrides
+
+    def _configured_default_model_for_provider(self, provider_name: str) -> str | None:
+        """Return an explicit user-configured default model for a provider, if any."""
+
+        identity = self._provider_identity(provider_name)
+        for key in (provider_name, identity):
+            config = self._config.provider_configs.get(key)
+            if not isinstance(config, dict):
+                continue
+            default_model = config.get("default_model")
+            if isinstance(default_model, str) and default_model.strip():
+                return default_model.strip()
+        return None
+
+    def _default_model_for_provider(self, provider_name: str) -> str | None:
+        """Resolve a default model override from subagent model packs when safe."""
+
+        if self._subagent_config is None:
+            return None
+
+        if provider_name == "openrouter":
+            if self._config.models and len(self._config.models) == 1:
+                return self._config.models[0]
+            return get_model_for_subagent(
+                self._subagent_config,
+                self._resolved_mode,
+                model_pack=self._resolved_model_pack,
+            )
+
+        model_id = get_model_for_subagent(
+            self._subagent_config,
+            self._resolved_mode,
+            model_pack=self._resolved_model_pack,
+        )
+        if "/" not in model_id:
+            return None
+
+        model_provider, provider_model = model_id.split("/", 1)
+        if model_provider == provider_name:
+            return provider_model
+
+        return None
+
+    def _phase_temperature(self, default: float) -> float:
+        """Return phase temperature, honoring global override when set."""
+
+        return self._config.temperature if self._config.temperature is not None else default
+
+    def _provider_request_timeout_seconds(self, phase: str) -> float:
+        """Return a provider request timeout that settles just before the outer run timeout."""
+
+        base_timeout = max(float(self._config.timeout) - 1.0, 1.0)
+        if self._config.runtime_profile == RuntimeProfile.BOUNDED:
+            bounded_caps = {
+                "draft": 15.0,
+                "critique": 10.0,
+                "synthesis": 15.0,
+            }
+            return max(min(base_timeout, bounded_caps.get(phase, base_timeout)), 1.0)
+
+        return base_timeout
+
+    def _provider_retry_budget(self) -> int:
+        """Return the provider-level retry budget for degradation handling."""
+
+        if self._config.runtime_profile == RuntimeProfile.BOUNDED:
+            return 0
+        return 2
+
+    def _phase_max_tokens(self, default: int, *, phase: str) -> int:
+        """Return phase token limit, honoring runtime and global overrides."""
+
+        if self._config.max_tokens is not None:
+            return self._config.max_tokens
+
+        if self._config.runtime_profile == RuntimeProfile.BOUNDED:
+            bounded_caps = {
+                "draft": 2000,
+                "critique": 1200,
+                "synthesis": 3000,
+            }
+            return min(default, bounded_caps.get(phase, default))
+
+        return default
+
+    async def _collect_evidence_for_run(self) -> EvidenceBundle:
+        """Collect local evidence for capability-backed runs."""
+
+        if self._task is None or self._subagent_name is None or self._capability_plan is None:
+            return EvidenceBundle()
+        if self._config.disable_local_evidence:
+            return EvidenceBundle(
+                executed_capabilities=[],
+                pending_capabilities=list(self._capability_plan.required_capabilities),
+                items=[],
+            )
+
+        bundle = await collect_capability_evidence(
+            self._task,
+            self._subagent_name,
+            self._resolved_mode,
+            self._capability_plan,
+        )
+
+        if self._execution_plan is not None:
+            self._execution_plan["executed_capabilities"] = list(bundle.executed_capabilities)
+            self._execution_plan["pending_capabilities"] = list(bundle.pending_capabilities)
+            self._execution_plan["evidence_items"] = len(bundle.items)
+
+        return bundle
+
+    def _build_evidence_requirements_block(self) -> str:
+        """Build guidance block for non-prompt-only execution profiles."""
+
+        if self._capability_plan is None:
+            return ""
+        if self._capability_plan.execution_profile == "prompt_only":
+            return ""
+        if not self._capability_plan.evidence_requirements:
+            return ""
+
+        requirements = "\n".join(f"- {item}" for item in self._capability_plan.evidence_requirements)
+        return (
+            "## Execution Requirements\n"
+            f"This run is classified as `{self._capability_plan.execution_profile}` "
+            f"with budget `{self._capability_plan.budget_class}`.\n"
+            "Ground high-confidence claims in the provided context. If evidence is missing, "
+            "say so explicitly instead of fabricating support.\n"
+            + (
+                "Local evidence collection is disabled for this run. Use only the provided "
+                "reference material and state any resulting blind spots explicitly.\n"
+                if self._config.disable_local_evidence
+                else ""
+            )
+            + "\n"
+            f"{requirements}"
+        )
+
+    def _build_collected_evidence_block(self) -> str:
+        """Render collected runtime evidence into prompt context."""
+
+        if self._evidence_bundle is None:
+            return ""
+        return self._evidence_bundle.to_prompt_block()
 
     def _record_usage(self, provider: str, usage: Mapping[str, int] | None) -> None:
         """Accumulate token usage and call counts for cost estimation."""
@@ -613,6 +1283,44 @@ class Orchestrator:
                 return ValidationResult(ok=False, errors=errors, raw=raw_text)
 
         return ValidationResult(ok=True, data=parsed, raw=raw_text)
+
+    def _fallback_synthesis_from_drafts(
+        self, drafts: Mapping[str, str], phase_error: Exception
+    ) -> tuple[ValidationResult, int]:
+        """Attempt to recover a final result from any successful draft output."""
+
+        reason = self._format_exception_chain(phase_error)
+        fallback_errors: list[str] = []
+
+        for provider_name, draft_text in drafts.items():
+            if not draft_text:
+                continue
+
+            validation = self._validate_response(draft_text)
+            if validation.ok:
+                note = (
+                    f"Synthesis failed ({reason}); used validated draft output from {provider_name}."
+                )
+                self._append_degradation_note(note)
+                self._record_degraded_output("draft", provider_name, reason)
+                return (
+                    ValidationResult(
+                        ok=True,
+                        data=validation.data,
+                        raw=validation.raw,
+                        errors=[*validation.errors, note],
+                    ),
+                    0,
+                )
+
+            fallback_errors.extend(
+                f"Draft fallback {provider_name}: {error}" for error in validation.errors
+            )
+
+        note = f"Synthesis failed ({reason}); no validated draft fallback available."
+        self._append_degradation_note(note)
+        self._record_degraded_output("none", None, reason)
+        return (ValidationResult(ok=False, errors=[note, *fallback_errors]), 0)
 
     def _extract_json(self, text: str) -> dict[str, Any] | None:
         """Extract the first JSON object from a response string.
@@ -715,24 +1423,50 @@ class Orchestrator:
         """Format the draft prompt with task details."""
 
         context_block = self._build_context_block()
+        collected_evidence = self._build_collected_evidence_block()
+        evidence_block = self._build_evidence_requirements_block()
         schema_hint = ""
         if self._schema:
-            schema_hint = "\nReturn a draft that aligns with the JSON schema."
+            if self._config.runtime_profile == RuntimeProfile.BOUNDED:
+                schema_hint = (
+                    "\nReturn a concise draft analysis, not final JSON. Focus on the highest-signal "
+                    "findings with short evidence-backed notes. Keep the draft brief."
+                )
+            else:
+                schema_hint = "\nReturn a draft that aligns with the JSON schema."
         tier_hint = f"\nSummary tier: {self._config.summary_tier.value}"
-        return f"Task:\n{task}\n{context_block}{schema_hint}{tier_hint}\n"
+        return (
+            f"Task:\n{task}\n{context_block}{collected_evidence}{evidence_block}"
+            f"{schema_hint}{tier_hint}\n"
+        )
 
     def _format_critique_prompt(self, task: str, drafts: dict[str, str]) -> str:
         """Format critique prompt with all drafts."""
 
         context_block = self._build_context_block()
+        collected_evidence = self._build_collected_evidence_block()
+        evidence_block = self._build_evidence_requirements_block()
         draft_blocks = "\n\n".join(
-            f"Provider: {name}\nDraft:\n{content}" for name, content in drafts.items()
+            f"Provider: {name}\nDraft:\n{content}"
+            for name, content in drafts.items()
+            if content.strip()
         )
+        if not draft_blocks:
+            draft_blocks = "No successful draft responses available."
         schema_hint = ""
-        if self._schema:
+        if self._schema and self._config.runtime_profile != RuntimeProfile.BOUNDED:
             schema_hint = "\nSchema (JSON):\n" + json.dumps(self._schema, indent=2)
+        elif self._schema:
+            schema_hint = (
+                "\nFocus on correctness and contradictions in the draft analyses. Do not produce final "
+                "JSON; synthesis will handle the schema."
+            )
         tier_hint = f"\nSummary tier: {self._config.summary_tier.value}"
-        return f"Task:\n{task}\n{context_block}{schema_hint}{tier_hint}\n\nDrafts:\n{draft_blocks}"
+        return (
+            f"Task:\n{task}\n{context_block}{collected_evidence}{evidence_block}"
+            f"{schema_hint}{tier_hint}\n\n"
+            f"Drafts:\n{draft_blocks}"
+        )
 
     def _format_synthesis_prompt(
         self,
@@ -745,13 +1479,19 @@ class Orchestrator:
         """Format synthesis prompt."""
 
         context_block = self._build_context_block()
+        collected_evidence = self._build_collected_evidence_block()
+        evidence_block = self._build_evidence_requirements_block()
         draft_blocks = "\n\n".join(
-            f"Provider: {name}\nDraft:\n{content}" for name, content in drafts.items()
+            f"Provider: {name}\nDraft:\n{content}"
+            for name, content in drafts.items()
+            if content.strip()
         )
+        if not draft_blocks:
+            draft_blocks = "No successful draft responses available."
         schema_block = json.dumps(schema, indent=2) if schema else "{}"
         error_block = "\n".join(f"- {err}" for err in errors) if errors else "None"
         return (
-            f"Task:\n{task}\n{context_block}\n"
+            f"Task:\n{task}\n{context_block}{collected_evidence}{evidence_block}\n"
             f"Schema (JSON):\n{schema_block}\n\n"
             f"Summary tier: {self._config.summary_tier.value}\n\n"
             f"Critique:\n{critique}\n\n"
@@ -763,27 +1503,69 @@ class Orchestrator:
     def _model_override(self, provider_name: str) -> str | None:
         """Return the model override for a provider if configured."""
 
-        return self._config.model_overrides.get(provider_name)
+        return self._resolved_model_overrides.get(provider_name) or self._config.model_overrides.get(
+            provider_name
+        )
 
-    async def _select_provider_for_phase(self, phase: str) -> tuple[str, ProviderAdapter]:
-        """Select a provider adapter for a given phase.
+    async def _candidate_providers_for_phase(self, phase: str) -> list[tuple[str, ProviderAdapter]]:
+        """Return ordered healthy provider candidates for a phase."""
 
-        Selection rules:
-        - For synthesis: prefer a provider that supports structured output (JSON schema).
-        - Otherwise: use the first configured provider that is available.
-        """
-
-        if not self._providers:
-            raise RuntimeError("No providers available for selection.")
+        healthy = [
+            (name, provider)
+            for name, provider in self._providers.items()
+            if name not in self._provider_init_errors
+        ]
+        if not healthy:
+            return []
 
         if phase == "synthesis":
-            for name, provider in self._providers.items():
+            structured = []
+            fallback = []
+            for name, provider in healthy:
                 if await provider.supports("structured_output"):
-                    return name, provider
+                    structured.append((name, provider))
+                else:
+                    fallback.append((name, provider))
+            return structured or fallback
 
-        # Fallback: first available provider.
-        name = next(iter(self._providers.keys()))
-        return name, self._providers[name]
+        return healthy
+
+    def _record_phase_provider_candidates(self, phase: str, provider_names: list[str]) -> None:
+        """Record ordered candidate providers for a phase in the execution plan."""
+
+        if self._execution_plan is None:
+            return
+        phase_candidates = self._execution_plan.setdefault("phase_provider_candidates", {})
+        phase_candidates[phase] = provider_names
+
+    def _record_phase_provider_used(self, phase: str, provider_name: str) -> None:
+        """Record the provider that succeeded for a phase in the execution plan."""
+
+        if self._execution_plan is None:
+            return
+        phase_used = self._execution_plan.setdefault("phase_provider_used", {})
+        phase_used[phase] = provider_name
+
+    def _append_degradation_note(self, note: str) -> None:
+        """Append a human-readable degradation note to the execution plan."""
+
+        if self._execution_plan is None:
+            return
+        notes = self._execution_plan.setdefault("degradation_notes", [])
+        notes.append(note)
+
+    def _record_degraded_output(
+        self, source: str, provider_name: str | None, reason: str
+    ) -> None:
+        """Record when the final output came from a degraded fallback path."""
+
+        if self._execution_plan is None:
+            return
+        self._execution_plan["degraded_output"] = {
+            "source": source,
+            "provider": provider_name,
+            "reason": reason,
+        }
 
     async def _timed(
         self, coro_factory: Callable[[], Awaitable[T]], phase: str
@@ -814,7 +1596,7 @@ class Orchestrator:
             except Exception as exc:
                 return name, DoctorResult(ok=False, message=str(exc))
 
-        pairs = await asyncio.gather(*[_check(name) for name in self._provider_names])
+        pairs = await asyncio.gather(*[_check(name) for name in self._configured_provider_names])
         for name, result in pairs:
             results[name] = result.model_dump()
         return results
@@ -826,8 +1608,6 @@ class Orchestrator:
         and only 'openrouter' is in the provider list, this method creates virtual
         providers for each model to enable parallel drafts from different LLMs.
         """
-        from llm_council.providers.openrouter import create_openrouter_for_model
-
         self._providers = {}
         self._provider_init_errors = {}
 
@@ -844,20 +1624,11 @@ class Orchestrator:
                 len(models),
                 ", ".join(models),
             )
-            for model in models:
-                # Use model name as provider name (e.g., "anthropic/claude-3.5-sonnet")
-                try:
-                    self._providers[model] = create_openrouter_for_model(model)
-                except Exception as exc:
-                    self._provider_init_errors[model] = str(exc)
+            self._providers, self._provider_init_errors = self._instantiate_providers(list(models))
         else:
-            # Standard provider initialization
-            for name in self._provider_names:
-                try:
-                    kwargs = self._config.provider_configs.get(name, {})
-                    self._providers[name] = self._registry.get_provider(name, **kwargs)
-                except Exception as exc:
-                    self._provider_init_errors[name] = str(exc)
+            self._providers, self._provider_init_errors = self._instantiate_providers(
+                self._provider_names
+            )
 
         if self._provider_init_errors:
             logger.debug("Provider initialization errors: %s", self._provider_init_errors)

--- a/src/llm_council/engine/orchestrator.py
+++ b/src/llm_council/engine/orchestrator.py
@@ -410,7 +410,9 @@ class Orchestrator:
             )
 
         try:
-            critique, critique_timing = await self._timed(lambda: self._run_critique(drafts), "critique")
+            critique, critique_timing = await self._timed(
+                lambda: self._run_critique(drafts), "critique"
+            )
             phase_timings.append(critique_timing)
 
             # Store critique as artifact if enabled
@@ -426,7 +428,9 @@ class Orchestrator:
         except Exception as exc:
             detail = self._format_exception_chain(exc)
             critique = ""
-            self._append_degradation_note(f"Critique failed ({detail}); continuing without critique.")
+            self._append_degradation_note(
+                f"Critique failed ({detail}); continuing without critique."
+            )
             logger.warning("Critique phase failed; continuing without critique: %s", detail)
 
         try:
@@ -566,7 +570,9 @@ class Orchestrator:
                     Message(role="user", content=user_prompt),
                 ],
                 timeout_seconds=self._provider_request_timeout_seconds("critique"),
-                max_tokens=self._phase_max_tokens(self._config.max_critique_tokens, phase="critique"),
+                max_tokens=self._phase_max_tokens(
+                    self._config.max_critique_tokens, phase="critique"
+                ),
                 temperature=self._phase_temperature(self._config.critique_temperature),
                 reasoning=self._reasoning,
             )
@@ -715,7 +721,9 @@ class Orchestrator:
 
         while True:
             try:
-                result = await asyncio.wait_for(adapter.generate(request), timeout=self._config.timeout)
+                result = await asyncio.wait_for(
+                    adapter.generate(request), timeout=self._config.timeout
+                )
                 if isinstance(result, GenerateResponse):
                     response = result
                 else:
@@ -767,7 +775,9 @@ class Orchestrator:
             requested_budget_class=self._config.budget_class,
             requested_capabilities=self._config.required_capabilities,
         )
-        self._system_prompt = get_effective_system_prompt(self._subagent_config, self._resolved_mode)
+        self._system_prompt = get_effective_system_prompt(
+            self._subagent_config, self._resolved_mode
+        )
         if self._config.model_pack:
             self._resolved_model_pack = self._config.model_pack
             self._model_pack_source = "config"
@@ -830,11 +840,15 @@ class Orchestrator:
             "execution_profile": (
                 self._capability_plan.execution_profile if self._capability_plan else "prompt_only"
             ),
-            "budget_class": self._capability_plan.budget_class if self._capability_plan else "normal",
+            "budget_class": self._capability_plan.budget_class
+            if self._capability_plan
+            else "normal",
             "required_capabilities": (
                 list(self._capability_plan.required_capabilities) if self._capability_plan else []
             ),
-            "registered_tools": list(self._capability_plan.tool_names) if self._capability_plan else [],
+            "registered_tools": list(self._capability_plan.tool_names)
+            if self._capability_plan
+            else [],
             "evidence_requirements": (
                 list(self._capability_plan.evidence_requirements) if self._capability_plan else []
             ),
@@ -933,7 +947,9 @@ class Orchestrator:
         if not self._providers:
             return
 
-        should_health_check = self._config.enable_health_check or self._should_attempt_provider_auto_fallback()
+        should_health_check = (
+            self._config.enable_health_check or self._should_attempt_provider_auto_fallback()
+        )
         if not should_health_check:
             return
 
@@ -1023,7 +1039,7 @@ class Orchestrator:
                 }
 
     def _instantiate_providers(
-        self, provider_names: list[str]
+        self, provider_names: list[str], *, treat_as_models: bool = False
     ) -> tuple[dict[str, ProviderAdapter], dict[str, str]]:
         """Instantiate a set of providers without mutating run state."""
 
@@ -1033,7 +1049,7 @@ class Orchestrator:
         init_errors: dict[str, str] = {}
         for name in provider_names:
             try:
-                if "/" in name and name != "openrouter":
+                if treat_as_models or ("/" in name and name != "openrouter"):
                     providers[name] = create_openrouter_for_model(name)
                     continue
                 kwargs = self._config.provider_configs.get(name, {})
@@ -1207,7 +1223,9 @@ class Orchestrator:
         if not self._capability_plan.evidence_requirements:
             return ""
 
-        requirements = "\n".join(f"- {item}" for item in self._capability_plan.evidence_requirements)
+        requirements = "\n".join(
+            f"- {item}" for item in self._capability_plan.evidence_requirements
+        )
         return (
             "## Execution Requirements\n"
             f"This run is classified as `{self._capability_plan.execution_profile}` "
@@ -1298,9 +1316,7 @@ class Orchestrator:
 
             validation = self._validate_response(draft_text)
             if validation.ok:
-                note = (
-                    f"Synthesis failed ({reason}); used validated draft output from {provider_name}."
-                )
+                note = f"Synthesis failed ({reason}); used validated draft output from {provider_name}."
                 self._append_degradation_note(note)
                 self._record_degraded_output("draft", provider_name, reason)
                 return (
@@ -1503,9 +1519,9 @@ class Orchestrator:
     def _model_override(self, provider_name: str) -> str | None:
         """Return the model override for a provider if configured."""
 
-        return self._resolved_model_overrides.get(provider_name) or self._config.model_overrides.get(
+        return self._resolved_model_overrides.get(
             provider_name
-        )
+        ) or self._config.model_overrides.get(provider_name)
 
     async def _candidate_providers_for_phase(self, phase: str) -> list[tuple[str, ProviderAdapter]]:
         """Return ordered healthy provider candidates for a phase."""
@@ -1554,9 +1570,7 @@ class Orchestrator:
         notes = self._execution_plan.setdefault("degradation_notes", [])
         notes.append(note)
 
-    def _record_degraded_output(
-        self, source: str, provider_name: str | None, reason: str
-    ) -> None:
+    def _record_degraded_output(self, source: str, provider_name: str | None, reason: str) -> None:
         """Record when the final output came from a degraded fallback path."""
 
         if self._execution_plan is None:
@@ -1624,7 +1638,9 @@ class Orchestrator:
                 len(models),
                 ", ".join(models),
             )
-            self._providers, self._provider_init_errors = self._instantiate_providers(list(models))
+            self._providers, self._provider_init_errors = self._instantiate_providers(
+                list(models), treat_as_models=True
+            )
         else:
             self._providers, self._provider_init_errors = self._instantiate_providers(
                 self._provider_names

--- a/src/llm_council/eval_import.py
+++ b/src/llm_council/eval_import.py
@@ -1,0 +1,269 @@
+"""Local-only import helpers for external review benchmark material."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DEFAULT_PRIVATE_IMPORT_ROOT = Path(".council-private/imports/github")
+GREPTILE_AUTHOR_MARKERS = ("greptile",)
+GREPTILE_COMMENT_BLOCK_RE = re.compile(
+    r"<!--\s*greptile_comment\s*-->.*?<!--\s*/greptile_comment\s*-->",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+class ImportedReviewComment(BaseModel):
+    """Normalized inline review comment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    comment_id: int
+    author_login: str
+    file_path: str | None = None
+    line_start: int | None = None
+    line_end: int | None = None
+    severity: str | None = None
+    body_markdown: str
+    body_text: str
+    suggested_code: str | None = None
+    addressed: bool | None = None
+
+
+class ImportedPullRequest(BaseModel):
+    """Locally stored PR import record."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    repo: str
+    pr_number: int
+    title: str
+    state: str
+    is_draft: bool
+    base_ref: str
+    head_ref: str
+    additions: int
+    deletions: int
+    changed_files: int
+    url: str
+    import_root: str
+    diff_path: str
+    review_input_path: str
+    metadata_path: str
+    raw_comments_path: str
+    greptile_labels_path: str
+    imported_comment_count: int
+
+
+def import_github_pr_review(
+    repo: str,
+    pr_number: int,
+    *,
+    output_root: str | Path | None = None,
+    max_diff_lines: int | None = None,
+) -> ImportedPullRequest:
+    """Import one GitHub PR into a local-only review benchmark bundle."""
+
+    root = Path(output_root) if output_root else DEFAULT_PRIVATE_IMPORT_ROOT
+    import_dir = root / _repo_slug(repo) / f"pr-{pr_number}"
+    import_dir.mkdir(parents=True, exist_ok=True)
+
+    pr_data = _gh_json(
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,state,isDraft,baseRefName,headRefName,additions,deletions,changedFiles,url",
+        ]
+    )
+    comments_data = _gh_json(
+        [
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/comments?per_page=100",
+        ]
+    )
+    diff_text = _gh_text(
+        [
+            "pr",
+            "diff",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--patch",
+            "--color=never",
+        ]
+    )
+    if max_diff_lines is not None and max_diff_lines > 0:
+        diff_text = _truncate_diff(diff_text, max_diff_lines=max_diff_lines)
+
+    greptile_comments = [
+        _normalize_review_comment(item)
+        for item in comments_data
+        if _is_greptile_author(item.get("user", {}).get("login"))
+    ]
+
+    metadata_path = import_dir / "pr.json"
+    raw_comments_path = import_dir / "review_comments.raw.json"
+    labels_path = import_dir / "greptile_labels.json"
+    diff_path = import_dir / "diff.patch"
+    review_input_path = import_dir / "review_input.md"
+
+    metadata_path.write_text(json.dumps(pr_data, indent=2), encoding="utf-8")
+    raw_comments_path.write_text(json.dumps(comments_data, indent=2), encoding="utf-8")
+    labels_path.write_text(
+        json.dumps([item.model_dump() for item in greptile_comments], indent=2),
+        encoding="utf-8",
+    )
+    diff_path.write_text(diff_text, encoding="utf-8")
+    review_input_path.write_text(
+        _build_review_input_markdown(pr_data, repo=repo, diff_text=diff_text),
+        encoding="utf-8",
+    )
+
+    return ImportedPullRequest(
+        repo=repo,
+        pr_number=pr_number,
+        title=pr_data["title"],
+        state=pr_data["state"],
+        is_draft=bool(pr_data["isDraft"]),
+        base_ref=pr_data["baseRefName"],
+        head_ref=pr_data["headRefName"],
+        additions=int(pr_data["additions"]),
+        deletions=int(pr_data["deletions"]),
+        changed_files=int(pr_data["changedFiles"]),
+        url=pr_data["url"],
+        import_root=str(import_dir),
+        diff_path=str(diff_path),
+        review_input_path=str(review_input_path),
+        metadata_path=str(metadata_path),
+        raw_comments_path=str(raw_comments_path),
+        greptile_labels_path=str(labels_path),
+        imported_comment_count=len(greptile_comments),
+    )
+
+
+def _gh_json(args: list[str]) -> Any:
+    output = _gh_text(args)
+    return json.loads(output)
+
+
+def _gh_text(args: list[str]) -> str:
+    command = ["gh", *args]
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def _repo_slug(repo: str) -> str:
+    return repo.replace("/", "__")
+
+
+def _is_greptile_author(login: str | None) -> bool:
+    normalized = (login or "").lower()
+    return any(marker in normalized for marker in GREPTILE_AUTHOR_MARKERS)
+
+
+def _normalize_review_comment(payload: dict[str, Any]) -> ImportedReviewComment:
+    body_markdown = payload.get("body") or ""
+    suggestion = _extract_suggested_code(body_markdown)
+    return ImportedReviewComment(
+        comment_id=int(payload["id"]),
+        author_login=payload.get("user", {}).get("login") or "",
+        file_path=payload.get("path"),
+        line_start=payload.get("line") or payload.get("start_line"),
+        line_end=payload.get("line") or payload.get("start_line"),
+        severity=_extract_severity(body_markdown),
+        body_markdown=body_markdown,
+        body_text=_normalize_comment_text(body_markdown),
+        suggested_code=suggestion,
+        addressed=None,
+    )
+
+
+def _extract_severity(body: str) -> str | None:
+    match = re.search(r'alt="(P[0-3])"', body, re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
+    match = re.search(r"\b(P[0-3])\b", body)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
+def _extract_suggested_code(body: str) -> str | None:
+    match = re.search(r"```suggestion\n(.*?)```", body, re.DOTALL)
+    if not match:
+        return None
+    return match.group(1).rstrip()
+
+
+def _normalize_comment_text(body: str) -> str:
+    stripped = re.sub(r"<[^>]+>", "", body)
+    stripped = html.unescape(stripped)
+    stripped = re.sub(r"```suggestion.*?```", "", stripped, flags=re.DOTALL)
+    stripped = re.sub(r"`([^`]+)`", r"\1", stripped)
+    stripped = re.sub(r"\s+\n", "\n", stripped)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+    return stripped.strip()
+
+
+def _build_review_input_markdown(pr_data: dict[str, Any], *, repo: str, diff_text: str) -> str:
+    body = _strip_greptile_block(pr_data.get("body") or "")
+    lines = [
+        "# Pull Request Review Input",
+        "",
+        f"- Repo: `{repo}`",
+        f"- PR: `{pr_data['number']}`",
+        f"- Title: {pr_data['title']}",
+        f"- State: {pr_data['state']}",
+        f"- Draft: {'yes' if pr_data['isDraft'] else 'no'}",
+        f"- Base: `{pr_data['baseRefName']}`",
+        f"- Head: `{pr_data['headRefName']}`",
+        f"- Changed files: {pr_data['changedFiles']}",
+        f"- Additions: {pr_data['additions']}",
+        f"- Deletions: {pr_data['deletions']}",
+        "",
+        "## PR Description",
+        body.strip() or "_No description provided._",
+        "",
+        "## Patch",
+        "```diff",
+        diff_text.rstrip(),
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _strip_greptile_block(body: str) -> str:
+    return GREPTILE_COMMENT_BLOCK_RE.sub("", body).strip()
+
+
+def _truncate_diff(diff_text: str, *, max_diff_lines: int) -> str:
+    lines = diff_text.splitlines()
+    if len(lines) <= max_diff_lines:
+        return diff_text
+    head = lines[:max_diff_lines]
+    head.append(f"... [truncated diff at {max_diff_lines} lines]")
+    return "\n".join(head) + "\n"
+
+
+__all__ = [
+    "DEFAULT_PRIVATE_IMPORT_ROOT",
+    "ImportedPullRequest",
+    "ImportedReviewComment",
+    "import_github_pr_review",
+]

--- a/src/llm_council/evaluation.py
+++ b/src/llm_council/evaluation.py
@@ -194,10 +194,7 @@ def load_eval_dataset(path: str | Path) -> EvalDataset:
 
     dataset_path = Path(path)
     raw = dataset_path.read_text(encoding="utf-8")
-    if dataset_path.suffix.lower() == ".json":
-        data = json.loads(raw)
-    else:
-        data = yaml.safe_load(raw)
+    data = json.loads(raw) if dataset_path.suffix.lower() == ".json" else yaml.safe_load(raw)
     if not isinstance(data, dict):
         raise ValueError(f"Evaluation dataset must be an object: {dataset_path}")
     dataset = EvalDataset.model_validate(data)
@@ -210,10 +207,9 @@ def load_eval_variants(path: str | Path) -> EvalVariantsFile:
 
     variants_path = Path(path)
     raw = variants_path.read_text(encoding="utf-8")
-    if variants_path.suffix.lower() == ".json":
-        data = json.loads(raw)
-    else:
-        data = yaml.safe_load(raw)
+    data = (
+        json.loads(raw) if variants_path.suffix.lower() == ".json" else yaml.safe_load(raw)
+    )
     if not isinstance(data, dict):
         raise ValueError(f"Evaluation variants file must be an object: {variants_path}")
     return EvalVariantsFile.model_validate(data)

--- a/src/llm_council/evaluation.py
+++ b/src/llm_council/evaluation.py
@@ -1,0 +1,663 @@
+"""Dataset-driven evaluation harness for council runs."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+
+from llm_council.council import Council
+from llm_council.engine.orchestrator import CouncilResult
+from llm_council.protocol.types import CouncilConfig, ReasoningProfile, RuntimeProfile
+
+
+class EvalExpectations(BaseModel):
+    """Deterministic checks for a single evaluation case."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool | None = True
+    routed: bool | None = None
+    execution_plan_values: dict[str, Any] = Field(default_factory=dict)
+    required_capabilities: list[str] = Field(default_factory=list)
+    executed_capabilities: list[str] = Field(default_factory=list)
+    pending_capabilities: list[str] | None = None
+    minimum_evidence_items: int | None = None
+    output_keys: list[str] = Field(default_factory=list)
+    output_contains: list[str] = Field(default_factory=list)
+    output_contains_any: list[str] = Field(default_factory=list)
+    minimum_output_contains_any_matches: int | None = None
+    output_not_contains: list[str] = Field(default_factory=list)
+
+
+class EvalCase(BaseModel):
+    """One evaluation case."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    task: str
+    subagent: str
+    mode: str | None = None
+    follow_router: bool = False
+    model_pack: str | None = None
+    execution_profile: str | None = None
+    budget_class: str | None = None
+    required_capabilities: list[str] = Field(default_factory=list)
+    disable_local_evidence: bool = False
+    context_file: str | None = None
+    system_context: str | None = None
+    expectations: EvalExpectations = Field(default_factory=EvalExpectations)
+
+    @property
+    def mode_key(self) -> str:
+        """Return a stable mode bucket for scorecards."""
+
+        return f"{self.subagent}:{self.mode or 'default'}"
+
+
+class EvalDataset(BaseModel):
+    """Evaluation dataset definition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    name: str
+    description: str | None = None
+    cases: list[EvalCase]
+    _source_path: Path | None = PrivateAttr(default=None)
+
+
+class EvalCriterionResult(BaseModel):
+    """Outcome of one deterministic criterion."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    passed: bool
+    expected: Any | None = None
+    actual: Any | None = None
+    message: str | None = None
+
+
+class EvalCaseResult(BaseModel):
+    """Evaluation result for a single case."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    mode_key: str
+    passed: bool
+    success: bool
+    error: str | None = None
+    validation_errors: list[str] | None = None
+    provider_errors: dict[str, str] | None = None
+    duration_ms: int
+    criteria: list[EvalCriterionResult]
+    execution_plan: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvalModeScorecard(BaseModel):
+    """Aggregated scorecard for one subagent/mode bucket."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode_key: str
+    total_cases: int
+    passed_cases: int
+    case_pass_rate: float
+    total_criteria: int
+    passed_criteria: int
+    criteria_pass_rate: float
+    average_duration_ms: int
+
+
+class EvalReport(BaseModel):
+    """Full evaluation report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_name: str
+    dataset_description: str | None = None
+    total_cases: int
+    passed_cases: int
+    failed_cases: int
+    case_pass_rate: float
+    total_criteria: int
+    passed_criteria: int
+    criteria_pass_rate: float
+    duration_ms: int
+    mode_scorecards: list[EvalModeScorecard]
+    case_results: list[EvalCaseResult]
+
+
+class EvalVariant(BaseModel):
+    """One named runtime variant for eval comparison."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str | None = None
+    providers: list[str] = Field(default_factory=list)
+    models: list[str] | None = None
+    model_overrides: dict[str, str] = Field(default_factory=dict)
+    provider_configs: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    enable_health_check: bool | None = None
+    runtime_profile: RuntimeProfile | None = None
+    reasoning_profile: ReasoningProfile | None = None
+
+
+class EvalVariantsFile(BaseModel):
+    """Collection of named eval variants loaded from disk."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    name: str
+    description: str | None = None
+    variants: list[EvalVariant]
+
+
+class EvalVariantResult(BaseModel):
+    """Evaluation outcome for one named variant."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variant_name: str
+    description: str | None = None
+    providers: list[str]
+    models: list[str] | None = None
+    model_overrides: dict[str, str] = Field(default_factory=dict)
+    report: EvalReport
+
+
+class EvalComparisonReport(BaseModel):
+    """Comparison report across multiple runtime variants."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_name: str
+    dataset_description: str | None = None
+    variants_name: str | None = None
+    variants_description: str | None = None
+    best_variant: str | None = None
+    ranking: list[str] = Field(default_factory=list)
+    variant_results: list[EvalVariantResult]
+
+
+def load_eval_dataset(path: str | Path) -> EvalDataset:
+    """Load an evaluation dataset from YAML or JSON."""
+
+    dataset_path = Path(path)
+    raw = dataset_path.read_text(encoding="utf-8")
+    if dataset_path.suffix.lower() == ".json":
+        data = json.loads(raw)
+    else:
+        data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        raise ValueError(f"Evaluation dataset must be an object: {dataset_path}")
+    dataset = EvalDataset.model_validate(data)
+    dataset._source_path = dataset_path
+    return dataset
+
+
+def load_eval_variants(path: str | Path) -> EvalVariantsFile:
+    """Load a named variant set from YAML or JSON."""
+
+    variants_path = Path(path)
+    raw = variants_path.read_text(encoding="utf-8")
+    if variants_path.suffix.lower() == ".json":
+        data = json.loads(raw)
+    else:
+        data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        raise ValueError(f"Evaluation variants file must be an object: {variants_path}")
+    return EvalVariantsFile.model_validate(data)
+
+
+async def run_eval_dataset(
+    dataset: EvalDataset,
+    *,
+    base_config: CouncilConfig | None = None,
+    case_ids: list[str] | None = None,
+    max_cases: int | None = None,
+    fail_fast: bool = False,
+) -> EvalReport:
+    """Run a dataset and compute deterministic scorecards."""
+
+    started = time.perf_counter()
+    selected_cases = _select_cases(dataset.cases, case_ids=case_ids, max_cases=max_cases)
+    results: list[EvalCaseResult] = []
+    config = base_config or CouncilConfig()
+
+    for case in selected_cases:
+        case_config = config.model_copy(
+            update={
+                "mode": case.mode,
+                "model_pack": case.model_pack,
+                "execution_profile": case.execution_profile,
+                "budget_class": case.budget_class,
+                "required_capabilities": list(case.required_capabilities),
+                "disable_local_evidence": case.disable_local_evidence,
+                "system_context": _load_case_context(case, dataset),
+                "follow_router": case.follow_router,
+            }
+        )
+        council = Council(config=case_config)
+        result = await council.run(
+            task=case.task,
+            subagent=case.subagent,
+            follow_router=case.follow_router,
+        )
+        case_result = evaluate_case_result(case, result)
+        results.append(case_result)
+        if fail_fast and not case_result.passed:
+            break
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    return build_eval_report(dataset, results, duration_ms=duration_ms)
+
+
+async def run_eval_comparison(
+    dataset: EvalDataset,
+    variants: EvalVariantsFile,
+    *,
+    base_config: CouncilConfig | None = None,
+    variant_names: list[str] | None = None,
+    case_ids: list[str] | None = None,
+    max_cases: int | None = None,
+    fail_fast: bool = False,
+) -> EvalComparisonReport:
+    """Run the same dataset against multiple named runtime variants."""
+
+    base = base_config or CouncilConfig()
+    results: list[EvalVariantResult] = []
+    selected_variants = _select_variants(variants.variants, variant_names=variant_names)
+
+    for variant in selected_variants:
+        variant_config = _merge_variant_config(base, variant)
+        report = await run_eval_dataset(
+            dataset,
+            base_config=variant_config,
+            case_ids=case_ids,
+            max_cases=max_cases,
+            fail_fast=fail_fast,
+        )
+        results.append(
+            EvalVariantResult(
+                variant_name=variant.name,
+                description=variant.description,
+                providers=list(variant_config.providers),
+                models=list(variant_config.models) if variant_config.models else None,
+                model_overrides=dict(variant_config.model_overrides),
+                report=report,
+            )
+        )
+
+    ranked = sorted(
+        results,
+        key=lambda item: (
+            item.report.case_pass_rate,
+            item.report.criteria_pass_rate,
+            -item.report.duration_ms,
+        ),
+        reverse=True,
+    )
+    ranking = [item.variant_name for item in ranked]
+    return EvalComparisonReport(
+        dataset_name=dataset.name,
+        dataset_description=dataset.description,
+        variants_name=variants.name,
+        variants_description=variants.description,
+        best_variant=ranking[0] if ranking else None,
+        ranking=ranking,
+        variant_results=results,
+    )
+
+
+def evaluate_case_result(case: EvalCase, result: CouncilResult) -> EvalCaseResult:
+    """Evaluate one council result against deterministic expectations."""
+
+    criteria: list[EvalCriterionResult] = []
+    expectations = case.expectations
+    execution_plan = result.execution_plan or {}
+    output = result.output or {}
+    output_text = json.dumps(output, sort_keys=True).lower()
+
+    if expectations.success is not None:
+        criteria.append(
+            _criterion(
+                "success",
+                result.success == expectations.success,
+                expected=expectations.success,
+                actual=result.success,
+            )
+        )
+
+    if expectations.routed is not None:
+        criteria.append(
+            _criterion(
+                "routed",
+                result.routed == expectations.routed,
+                expected=expectations.routed,
+                actual=result.routed,
+            )
+        )
+
+    for key, expected_value in expectations.execution_plan_values.items():
+        actual_value = execution_plan.get(key)
+        criteria.append(
+            _criterion(
+                f"execution_plan.{key}",
+                actual_value == expected_value,
+                expected=expected_value,
+                actual=actual_value,
+            )
+        )
+
+    if expectations.required_capabilities:
+        actual_capabilities = list(execution_plan.get("required_capabilities") or [])
+        missing = [item for item in expectations.required_capabilities if item not in actual_capabilities]
+        criteria.append(
+            _criterion(
+                "required_capabilities",
+                not missing,
+                expected=expectations.required_capabilities,
+                actual=actual_capabilities,
+                message=f"Missing required capabilities: {', '.join(missing)}" if missing else None,
+            )
+        )
+
+    if expectations.executed_capabilities:
+        actual_executed = list(execution_plan.get("executed_capabilities") or [])
+        missing = [item for item in expectations.executed_capabilities if item not in actual_executed]
+        criteria.append(
+            _criterion(
+                "executed_capabilities",
+                not missing,
+                expected=expectations.executed_capabilities,
+                actual=actual_executed,
+                message=f"Missing executed capabilities: {', '.join(missing)}" if missing else None,
+            )
+        )
+
+    if expectations.pending_capabilities is not None:
+        actual_pending = sorted(execution_plan.get("pending_capabilities") or [])
+        expected_pending = sorted(expectations.pending_capabilities)
+        criteria.append(
+            _criterion(
+                "pending_capabilities",
+                actual_pending == expected_pending,
+                expected=expected_pending,
+                actual=actual_pending,
+            )
+        )
+
+    if expectations.minimum_evidence_items is not None:
+        actual_evidence_items = int(execution_plan.get("evidence_items") or 0)
+        criteria.append(
+            _criterion(
+                "minimum_evidence_items",
+                actual_evidence_items >= expectations.minimum_evidence_items,
+                expected=expectations.minimum_evidence_items,
+                actual=actual_evidence_items,
+            )
+        )
+
+    if expectations.output_keys:
+        actual_keys = sorted(output.keys())
+        missing = [item for item in expectations.output_keys if item not in output]
+        criteria.append(
+            _criterion(
+                "output_keys",
+                not missing,
+                expected=expectations.output_keys,
+                actual=actual_keys,
+                message=f"Missing output keys: {', '.join(missing)}" if missing else None,
+            )
+        )
+
+    for item in expectations.output_contains:
+        lowered = item.lower()
+        criteria.append(
+            _criterion(
+                f"output_contains:{item}",
+                lowered in output_text,
+                expected=item,
+                actual=output_text,
+            )
+        )
+
+    if expectations.output_contains_any:
+        matched_items = [item for item in expectations.output_contains_any if item.lower() in output_text]
+        minimum_matches = expectations.minimum_output_contains_any_matches or 1
+        criteria.append(
+            _criterion(
+                "output_contains_any",
+                len(matched_items) >= minimum_matches,
+                expected={
+                    "minimum_matches": minimum_matches,
+                    "phrases": expectations.output_contains_any,
+                },
+                actual={
+                    "matched_count": len(matched_items),
+                    "matched_phrases": matched_items,
+                },
+                message=f"Matched {len(matched_items)} expected clues",
+            )
+        )
+
+    for item in expectations.output_not_contains:
+        lowered = item.lower()
+        criteria.append(
+            _criterion(
+                f"output_not_contains:{item}",
+                lowered not in output_text,
+                expected=item,
+                actual=output_text,
+            )
+        )
+
+    passed = all(item.passed for item in criteria)
+    return EvalCaseResult(
+        case_id=case.id,
+        mode_key=case.mode_key,
+        passed=passed,
+        success=result.success,
+        error=result.error,
+        validation_errors=list(result.validation_errors) if result.validation_errors else None,
+        provider_errors=dict(result.provider_errors) if result.provider_errors else None,
+        duration_ms=result.duration_ms,
+        criteria=criteria,
+        execution_plan=execution_plan,
+    )
+
+
+def build_eval_report(
+    dataset: EvalDataset,
+    case_results: list[EvalCaseResult],
+    *,
+    duration_ms: int,
+) -> EvalReport:
+    """Aggregate case results into a report and per-mode scorecards."""
+
+    total_cases = len(case_results)
+    passed_cases = sum(1 for item in case_results if item.passed)
+    failed_cases = total_cases - passed_cases
+    total_criteria = sum(len(item.criteria) for item in case_results)
+    passed_criteria = sum(1 for item in case_results for criterion in item.criteria if criterion.passed)
+
+    return EvalReport(
+        dataset_name=dataset.name,
+        dataset_description=dataset.description,
+        total_cases=total_cases,
+        passed_cases=passed_cases,
+        failed_cases=failed_cases,
+        case_pass_rate=_ratio(passed_cases, total_cases),
+        total_criteria=total_criteria,
+        passed_criteria=passed_criteria,
+        criteria_pass_rate=_ratio(passed_criteria, total_criteria),
+        duration_ms=duration_ms,
+        mode_scorecards=_build_mode_scorecards(case_results),
+        case_results=case_results,
+    )
+
+
+def _select_cases(
+    cases: list[EvalCase],
+    *,
+    case_ids: list[str] | None,
+    max_cases: int | None,
+) -> list[EvalCase]:
+    selected = cases
+    if case_ids:
+        case_id_set = set(case_ids)
+        selected = [case for case in selected if case.id in case_id_set]
+    if max_cases is not None:
+        selected = selected[:max_cases]
+    return selected
+
+
+def _select_variants(
+    variants: list[EvalVariant],
+    *,
+    variant_names: list[str] | None,
+) -> list[EvalVariant]:
+    """Select requested variants while preserving file order."""
+
+    if not variant_names:
+        return variants
+
+    requested = {name.strip() for name in variant_names if name.strip()}
+    selected = [variant for variant in variants if variant.name in requested]
+    missing = sorted(requested - {variant.name for variant in selected})
+    if missing:
+        raise ValueError(f"Unknown eval variant(s): {', '.join(missing)}")
+    return selected
+
+
+def _merge_variant_config(base: CouncilConfig, variant: EvalVariant) -> CouncilConfig:
+    """Merge a named variant onto a base council config."""
+
+    provider_configs = {
+        key: dict(value) for key, value in base.provider_configs.items()
+    }
+    for provider_name, config in variant.provider_configs.items():
+        provider_configs[provider_name] = dict(config)
+
+    model_overrides = dict(base.model_overrides)
+    model_overrides.update(variant.model_overrides)
+
+    return base.model_copy(
+        update={
+            "providers": list(variant.providers) if variant.providers else list(base.providers),
+            "models": list(variant.models) if variant.models is not None else base.models,
+            "provider_configs": provider_configs,
+            "model_overrides": model_overrides,
+            "runtime_profile": (
+                variant.runtime_profile
+                if variant.runtime_profile is not None
+                else base.runtime_profile
+            ),
+            "reasoning_profile": (
+                variant.reasoning_profile
+                if variant.reasoning_profile is not None
+                else base.reasoning_profile
+            ),
+            "enable_health_check": (
+                variant.enable_health_check
+                if variant.enable_health_check is not None
+                else base.enable_health_check
+            ),
+        }
+    )
+
+
+def _load_case_context(case: EvalCase, dataset: EvalDataset) -> str | None:
+    parts: list[str] = []
+    if case.system_context:
+        parts.append(case.system_context)
+    if case.context_file:
+        context_path = Path(case.context_file)
+        if not context_path.is_absolute() and dataset._source_path is not None:
+            context_path = dataset._source_path.parent / context_path
+        parts.append(context_path.read_text(encoding="utf-8"))
+    if not parts:
+        return None
+    return "\n\n".join(part for part in parts if part)
+
+
+def _build_mode_scorecards(case_results: list[EvalCaseResult]) -> list[EvalModeScorecard]:
+    buckets: dict[str, list[EvalCaseResult]] = {}
+    for result in case_results:
+        buckets.setdefault(result.mode_key, []).append(result)
+
+    scorecards: list[EvalModeScorecard] = []
+    for mode_key in sorted(buckets):
+        items = buckets[mode_key]
+        total_cases = len(items)
+        passed_cases = sum(1 for item in items if item.passed)
+        total_criteria = sum(len(item.criteria) for item in items)
+        passed_criteria = sum(1 for item in items for criterion in item.criteria if criterion.passed)
+        average_duration_ms = int(sum(item.duration_ms for item in items) / total_cases) if total_cases else 0
+        scorecards.append(
+            EvalModeScorecard(
+                mode_key=mode_key,
+                total_cases=total_cases,
+                passed_cases=passed_cases,
+                case_pass_rate=_ratio(passed_cases, total_cases),
+                total_criteria=total_criteria,
+                passed_criteria=passed_criteria,
+                criteria_pass_rate=_ratio(passed_criteria, total_criteria),
+                average_duration_ms=average_duration_ms,
+            )
+        )
+    return scorecards
+
+
+def _criterion(
+    name: str,
+    passed: bool,
+    *,
+    expected: Any | None = None,
+    actual: Any | None = None,
+    message: str | None = None,
+) -> EvalCriterionResult:
+    return EvalCriterionResult(
+        name=name,
+        passed=passed,
+        expected=expected,
+        actual=actual,
+        message=message,
+    )
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+__all__ = [
+    "EvalCase",
+    "EvalCaseResult",
+    "EvalComparisonReport",
+    "EvalCriterionResult",
+    "EvalDataset",
+    "EvalExpectations",
+    "EvalModeScorecard",
+    "EvalReport",
+    "EvalVariant",
+    "EvalVariantResult",
+    "EvalVariantsFile",
+    "build_eval_report",
+    "evaluate_case_result",
+    "load_eval_dataset",
+    "load_eval_variants",
+    "run_eval_comparison",
+    "run_eval_dataset",
+]

--- a/src/llm_council/evaluation.py
+++ b/src/llm_council/evaluation.py
@@ -207,9 +207,7 @@ def load_eval_variants(path: str | Path) -> EvalVariantsFile:
 
     variants_path = Path(path)
     raw = variants_path.read_text(encoding="utf-8")
-    data = (
-        json.loads(raw) if variants_path.suffix.lower() == ".json" else yaml.safe_load(raw)
-    )
+    data = json.loads(raw) if variants_path.suffix.lower() == ".json" else yaml.safe_load(raw)
     if not isinstance(data, dict):
         raise ValueError(f"Evaluation variants file must be an object: {variants_path}")
     return EvalVariantsFile.model_validate(data)
@@ -357,7 +355,9 @@ def evaluate_case_result(case: EvalCase, result: CouncilResult) -> EvalCaseResul
 
     if expectations.required_capabilities:
         actual_capabilities = list(execution_plan.get("required_capabilities") or [])
-        missing = [item for item in expectations.required_capabilities if item not in actual_capabilities]
+        missing = [
+            item for item in expectations.required_capabilities if item not in actual_capabilities
+        ]
         criteria.append(
             _criterion(
                 "required_capabilities",
@@ -370,7 +370,9 @@ def evaluate_case_result(case: EvalCase, result: CouncilResult) -> EvalCaseResul
 
     if expectations.executed_capabilities:
         actual_executed = list(execution_plan.get("executed_capabilities") or [])
-        missing = [item for item in expectations.executed_capabilities if item not in actual_executed]
+        missing = [
+            item for item in expectations.executed_capabilities if item not in actual_executed
+        ]
         criteria.append(
             _criterion(
                 "executed_capabilities",
@@ -429,7 +431,9 @@ def evaluate_case_result(case: EvalCase, result: CouncilResult) -> EvalCaseResul
         )
 
     if expectations.output_contains_any:
-        matched_items = [item for item in expectations.output_contains_any if item.lower() in output_text]
+        matched_items = [
+            item for item in expectations.output_contains_any if item.lower() in output_text
+        ]
         minimum_matches = expectations.minimum_output_contains_any_matches or 1
         criteria.append(
             _criterion(
@@ -485,7 +489,9 @@ def build_eval_report(
     passed_cases = sum(1 for item in case_results if item.passed)
     failed_cases = total_cases - passed_cases
     total_criteria = sum(len(item.criteria) for item in case_results)
-    passed_criteria = sum(1 for item in case_results for criterion in item.criteria if criterion.passed)
+    passed_criteria = sum(
+        1 for item in case_results for criterion in item.criteria if criterion.passed
+    )
 
     return EvalReport(
         dataset_name=dataset.name,
@@ -539,9 +545,7 @@ def _select_variants(
 def _merge_variant_config(base: CouncilConfig, variant: EvalVariant) -> CouncilConfig:
     """Merge a named variant onto a base council config."""
 
-    provider_configs = {
-        key: dict(value) for key, value in base.provider_configs.items()
-    }
+    provider_configs = {key: dict(value) for key, value in base.provider_configs.items()}
     for provider_name, config in variant.provider_configs.items():
         provider_configs[provider_name] = dict(config)
 
@@ -598,8 +602,12 @@ def _build_mode_scorecards(case_results: list[EvalCaseResult]) -> list[EvalModeS
         total_cases = len(items)
         passed_cases = sum(1 for item in items if item.passed)
         total_criteria = sum(len(item.criteria) for item in items)
-        passed_criteria = sum(1 for item in items for criterion in item.criteria if criterion.passed)
-        average_duration_ms = int(sum(item.duration_ms for item in items) / total_cases) if total_cases else 0
+        passed_criteria = sum(
+            1 for item in items for criterion in item.criteria if criterion.passed
+        )
+        average_duration_ms = (
+            int(sum(item.duration_ms for item in items) / total_cases) if total_cases else 0
+        )
         scorecards.append(
             EvalModeScorecard(
                 mode_key=mode_key,

--- a/src/llm_council/protocol/types.py
+++ b/src/llm_council/protocol/types.py
@@ -23,6 +23,21 @@ class SummaryTier(str, Enum):
     AUDIT = "audit"  # Full detail for audit trail
 
 
+class ReasoningProfile(str, Enum):
+    """High-level reasoning intensity overrides for runtime execution."""
+
+    DEFAULT = "default"
+    OFF = "off"
+    LIGHT = "light"
+
+
+class RuntimeProfile(str, Enum):
+    """High-level execution budget overrides for council phases."""
+
+    DEFAULT = "default"
+    BOUNDED = "bounded"
+
+
 class CouncilConfig(BaseModel):
     """Configuration for a council run."""
 
@@ -87,6 +102,14 @@ class CouncilConfig(BaseModel):
         ge=1,
         description="Maximum output tokens",
     )
+    runtime_profile: RuntimeProfile = Field(
+        default=RuntimeProfile.DEFAULT,
+        description="High-level runtime budget override (default/bounded).",
+    )
+    reasoning_profile: ReasoningProfile = Field(
+        default=ReasoningProfile.DEFAULT,
+        description="High-level override for reasoning intensity (default/off/light).",
+    )
     system_context: str | None = Field(
         default=None,
         description="Additional system context/instructions to prepend",
@@ -94,6 +117,40 @@ class CouncilConfig(BaseModel):
     output_schema: dict[str, Any] | None = Field(
         default=None,
         description="Custom JSON schema for output validation",
+    )
+    model_pack: str | None = Field(
+        default=None,
+        description="Optional runtime model-pack override (e.g. deep_reasoner, grounded)",
+    )
+    model_overrides: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Explicit per-provider model overrides. "
+            "These are user-selected models and should take precedence over subagent defaults."
+        ),
+    )
+    execution_profile: str | None = Field(
+        default=None,
+        description="Optional execution-profile override (prompt_only, light_tools, grounded, deep_analysis)",
+    )
+    budget_class: str | None = Field(
+        default=None,
+        description="Optional budget-class override (cheap, normal, premium)",
+    )
+    required_capabilities: list[str] = Field(
+        default_factory=list,
+        description="Optional capability-pack overrides to merge into the run",
+    )
+    disable_local_evidence: bool = Field(
+        default=False,
+        description="Disable local evidence collection and rely only on provided reference material.",
+    )
+    follow_router: bool = Field(
+        default=False,
+        description=(
+            "If true, a router run is followed by a second run using the router's "
+            "recommended subagent and mode."
+        ),
     )
     provider_configs: dict[str, dict[str, Any]] = Field(
         default_factory=dict,
@@ -118,6 +175,10 @@ class CouncilRequest(BaseModel):
     mode: str | None = Field(
         default=None,
         description="Agent mode for consolidated agents",
+    )
+    follow_router: bool = Field(
+        default=False,
+        description="Follow router output by running the recommended subagent and mode",
     )
     config: CouncilConfig | None = Field(
         default=None,
@@ -194,6 +255,18 @@ class CouncilResponse(BaseModel):
     run_id: str | None = Field(
         default=None,
         description="Artifact store run ID",
+    )
+    routed: bool = Field(
+        default=False,
+        description="Whether this response came from a router-followed execution",
+    )
+    routing_decision: dict[str, Any] | None = Field(
+        default=None,
+        description="Router output used to select the routed subagent and mode",
+    )
+    routing_execution_plan: dict[str, Any] | None = Field(
+        default=None,
+        description="Execution plan produced by the router run before follow-up execution",
     )
 
 

--- a/src/llm_council/providers/base.py
+++ b/src/llm_council/providers/base.py
@@ -77,6 +77,14 @@ _MODEL_UNAVAILABLE_PATTERNS = (
     "capacity",
 )
 
+_TIMEOUT_PATTERNS = (
+    "timeout",
+    "timed out",
+    "read timed out",
+    "request timed out",
+    "deadline exceeded",
+)
+
 _NETWORK_PATTERNS = (
     "connection",
     "network",
@@ -122,6 +130,11 @@ def classify_error(error_text: str, return_code: int = -1) -> ErrorType:
     for pattern in _MODEL_UNAVAILABLE_PATTERNS:
         if pattern.lower() in error_lower:
             return ErrorType.MODEL_UNAVAILABLE
+
+    # Check timeouts before general network issues so read/deadline failures retry correctly
+    for pattern in _TIMEOUT_PATTERNS:
+        if pattern in error_lower:
+            return ErrorType.TIMEOUT
 
     # Check for network issues (retryable)
     for pattern in _NETWORK_PATTERNS:
@@ -250,6 +263,11 @@ class GenerateRequest(BaseModel):
     prompt: str | None = Field(default=None, description="Prompt string for simple use cases.")
     messages: Sequence[Message] | None = Field(
         default=None, description="Chat-style message sequence."
+    )
+    timeout_seconds: float | None = Field(
+        default=None,
+        gt=0,
+        description="Optional provider request timeout in seconds.",
     )
     max_tokens: int | None = Field(default=None, description="Maximum tokens to generate.")
     temperature: float | None = Field(default=None, ge=0.0, le=2.0)

--- a/src/llm_council/providers/cli/_subprocess.py
+++ b/src/llm_council/providers/cli/_subprocess.py
@@ -8,7 +8,9 @@ import os
 import signal
 
 
-async def terminate_process_tree(proc: asyncio.subprocess.Process, grace_seconds: float = 1.0) -> None:
+async def terminate_process_tree(
+    proc: asyncio.subprocess.Process, grace_seconds: float = 1.0
+) -> None:
     """Terminate a CLI subprocess and any children it spawned.
 
     CLI wrappers such as Node-based agents can leave child processes running after

--- a/src/llm_council/providers/cli/_subprocess.py
+++ b/src/llm_council/providers/cli/_subprocess.py
@@ -1,0 +1,34 @@
+"""Shared subprocess helpers for CLI-backed providers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+
+
+async def terminate_process_tree(proc: asyncio.subprocess.Process, grace_seconds: float = 1.0) -> None:
+    """Terminate a CLI subprocess and any children it spawned.
+
+    CLI wrappers such as Node-based agents can leave child processes running after
+    the parent receives a kill signal. Starting subprocesses in their own session
+    lets us terminate the whole process group and settle bounded council runs
+    promptly instead of leaking until the outer case timeout fires.
+    """
+
+    if proc.returncode is None:
+        try:
+            if hasattr(os, "killpg"):
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:  # pragma: no cover - Windows fallback
+                proc.kill()
+        except ProcessLookupError:
+            pass
+
+    try:
+        await asyncio.wait_for(proc.communicate(), timeout=grace_seconds)
+    except asyncio.TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        await proc.communicate()

--- a/src/llm_council/providers/cli/claude_code.py
+++ b/src/llm_council/providers/cli/claude_code.py
@@ -22,6 +22,7 @@ from typing import ClassVar
 
 import contextlib
 
+from llm_council.providers.cli._subprocess import terminate_process_tree
 from llm_council.providers.base import (
     DoctorResult,
     ErrorType,
@@ -59,7 +60,7 @@ class ClaudeCodeCLIProvider(ProviderAdapter):
     argument lists (no shell). Environment is restricted to an allowlist.
     """
 
-    name: ClassVar[str] = "claude-code"
+    name: ClassVar[str] = "claude"
     capabilities: ClassVar[ProviderCapabilities] = ProviderCapabilities(
         streaming=False,
         tool_use=False,
@@ -115,6 +116,11 @@ class ClaudeCodeCLIProvider(ProviderAdapter):
         """Get minimal environment with only allowlisted variables."""
         return {k: v for k, v in os.environ.items() if k in _ENV_ALLOWLIST}
 
+    def _request_timeout(self, request: GenerateRequest) -> float:
+        """Return the effective timeout for this request."""
+
+        return float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+
     async def generate(
         self, request: GenerateRequest
     ) -> GenerateResponse | AsyncIterator[GenerateResponse]:
@@ -131,15 +137,16 @@ class ClaudeCodeCLIProvider(ProviderAdapter):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=self._get_minimal_env(),
+            start_new_session=True,
         )
 
+        timeout = self._request_timeout(request)
         try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self._timeout)
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.communicate()
+            await terminate_process_tree(proc)
             raise RuntimeError(
-                f"Claude Code CLI timed out after {self._timeout}s. "
+                f"Claude Code CLI timed out after {timeout}s. "
                 "Consider increasing timeout or simplifying the task."
             )
 
@@ -237,7 +244,7 @@ def _register() -> None:
     from llm_council.providers.registry import get_registry
 
     with contextlib.suppress(ValueError):
-        get_registry().register_provider("claude-code", ClaudeCodeCLIProvider)
+        get_registry().register_provider("claude", ClaudeCodeCLIProvider)
 
 
 _register()

--- a/src/llm_council/providers/cli/claude_code.py
+++ b/src/llm_council/providers/cli/claude_code.py
@@ -118,7 +118,9 @@ class ClaudeCodeCLIProvider(ProviderAdapter):
     def _request_timeout(self, request: GenerateRequest) -> float:
         """Return the effective timeout for this request."""
 
-        return float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+        return (
+            float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+        )
 
     async def generate(
         self, request: GenerateRequest

--- a/src/llm_council/providers/cli/claude_code.py
+++ b/src/llm_council/providers/cli/claude_code.py
@@ -13,6 +13,7 @@ No shell is spawned; arguments are passed as a list directly to the binary.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -20,9 +21,6 @@ import shutil
 from collections.abc import AsyncIterator
 from typing import ClassVar
 
-import contextlib
-
-from llm_council.providers.cli._subprocess import terminate_process_tree
 from llm_council.providers.base import (
     DoctorResult,
     ErrorType,
@@ -33,6 +31,7 @@ from llm_council.providers.base import (
     classify_error,
     get_billing_help_url,
 )
+from llm_council.providers.cli._subprocess import terminate_process_tree
 
 logger = logging.getLogger(__name__)
 

--- a/src/llm_council/providers/cli/codex.py
+++ b/src/llm_council/providers/cli/codex.py
@@ -21,6 +21,7 @@ import warnings
 from collections.abc import AsyncIterator
 from typing import ClassVar
 
+from llm_council.providers.cli._subprocess import terminate_process_tree
 from llm_council.providers.base import (
     DoctorResult,
     ErrorType,
@@ -61,7 +62,7 @@ _ENV_ALLOWLIST = {
 class CodexCLIProvider(ProviderAdapter):
     """Codex CLI provider adapter."""
 
-    name: ClassVar[str] = "codex-cli"
+    name: ClassVar[str] = "codex"
     capabilities: ClassVar[ProviderCapabilities] = ProviderCapabilities(
         streaming=False,
         tool_use=False,
@@ -115,6 +116,11 @@ class CodexCLIProvider(ProviderAdapter):
         """Get minimal environment with only allowlisted variables."""
         return {k: v for k, v in os.environ.items() if k in _ENV_ALLOWLIST}
 
+    def _request_timeout(self, request: GenerateRequest) -> float:
+        """Return the effective timeout for this request."""
+
+        return float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+
     async def generate(
         self, request: GenerateRequest
     ) -> GenerateResponse | AsyncIterator[GenerateResponse]:
@@ -132,15 +138,16 @@ class CodexCLIProvider(ProviderAdapter):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=self._get_minimal_env(),
+            start_new_session=True,
         )
 
+        timeout = self._request_timeout(request)
         try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self._timeout)
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.communicate()
+            await terminate_process_tree(proc)
             raise RuntimeError(
-                f"Codex CLI timed out after {self._timeout}s. "
+                f"Codex CLI timed out after {timeout}s. "
                 "Consider increasing timeout or simplifying the task."
             )
 
@@ -185,14 +192,41 @@ class CodexCLIProvider(ProviderAdapter):
     async def doctor(self) -> DoctorResult:
         if not self._cli_path:
             return DoctorResult(ok=False, message="CLI not found")
-        return DoctorResult(ok=True, message="CLI available")
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._cli_path,
+                "login",
+                "status",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._get_minimal_env(),
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except asyncio.TimeoutError:
+            return DoctorResult(ok=False, message="CLI login status check timed out")
+        except Exception as exc:  # pragma: no cover - defensive path
+            return DoctorResult(ok=False, message=f"CLI login status check failed: {exc}")
+
+        output = stdout.decode("utf-8", errors="replace").strip()
+        error_output = stderr.decode("utf-8", errors="replace").strip()
+        status_text = output or error_output or f"CLI returned exit code {proc.returncode}"
+        lowered = status_text.lower()
+
+        if proc.returncode != 0:
+            return DoctorResult(ok=False, message=status_text)
+        if "not logged in" in lowered or "logged out" in lowered:
+            return DoctorResult(ok=False, message=status_text)
+        if "logged in" in lowered:
+            return DoctorResult(ok=True, message=status_text)
+        return DoctorResult(ok=True, message=f"CLI available ({status_text})")
 
 
 def _register() -> None:
     from llm_council.providers.registry import get_registry
 
     with contextlib.suppress(ValueError):
-        get_registry().register_provider("codex-cli", CodexCLIProvider)
+        get_registry().register_provider("codex", CodexCLIProvider)
 
 
 _register()

--- a/src/llm_council/providers/cli/codex.py
+++ b/src/llm_council/providers/cli/codex.py
@@ -21,7 +21,6 @@ import warnings
 from collections.abc import AsyncIterator
 from typing import ClassVar
 
-from llm_council.providers.cli._subprocess import terminate_process_tree
 from llm_council.providers.base import (
     DoctorResult,
     ErrorType,
@@ -32,6 +31,7 @@ from llm_council.providers.base import (
     classify_error,
     get_billing_help_url,
 )
+from llm_council.providers.cli._subprocess import terminate_process_tree
 
 logger = logging.getLogger(__name__)
 

--- a/src/llm_council/providers/cli/codex.py
+++ b/src/llm_council/providers/cli/codex.py
@@ -119,7 +119,9 @@ class CodexCLIProvider(ProviderAdapter):
     def _request_timeout(self, request: GenerateRequest) -> float:
         """Return the effective timeout for this request."""
 
-        return float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+        return (
+            float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+        )
 
     async def generate(
         self, request: GenerateRequest

--- a/src/llm_council/providers/cli/gemini.py
+++ b/src/llm_council/providers/cli/gemini.py
@@ -95,7 +95,9 @@ class GeminiCLIProvider(ProviderAdapter):
         mode = _APPROVAL_MODE_ALIASES.get(mode, mode)
         if mode not in _VALID_APPROVAL_MODES:
             valid = ", ".join(sorted(_VALID_APPROVAL_MODES))
-            raise ValueError(f"Unsupported Gemini approval mode '{approval_mode}'. Use one of: {valid}")
+            raise ValueError(
+                f"Unsupported Gemini approval mode '{approval_mode}'. Use one of: {valid}"
+            )
         return mode
 
     def _check_unsafe_mode(self) -> None:
@@ -110,7 +112,9 @@ class GeminiCLIProvider(ProviderAdapter):
     def _request_timeout(self, request: GenerateRequest) -> float:
         """Return the effective timeout for this request."""
 
-        return float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+        return (
+            float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
+        )
 
     def _build_command(self, request: GenerateRequest) -> list[str]:
         """Build CLI command as argument list (safe from injection)."""

--- a/src/llm_council/providers/cli/gemini.py
+++ b/src/llm_council/providers/cli/gemini.py
@@ -20,6 +20,7 @@ import warnings
 from collections.abc import AsyncIterator
 from typing import ClassVar
 
+from llm_council.providers.cli._subprocess import terminate_process_tree
 from llm_council.providers.base import (
     DoctorResult,
     ErrorType,
@@ -35,11 +36,17 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "gemini-2.0-flash-exp"
 # SECURITY: Least-privilege defaults - require approval for actions
-# Override via default_flags param for agentic mode
-DEFAULT_APPROVAL_MODE = "confirm"
+# Older adapter configs used "confirm"/"auto"; normalize them to the
+# current CLI vocabulary to stay backward compatible.
+DEFAULT_APPROVAL_MODE = "default"
+_APPROVAL_MODE_ALIASES = {
+    "confirm": "default",
+    "auto": "yolo",
+}
+_VALID_APPROVAL_MODES = {"default", "auto_edit", "yolo", "plan"}
 
 # Unsafe modes that require explicit opt-in
-_UNSAFE_MODES = {"yolo", "auto"}
+_UNSAFE_MODES = {"yolo"}
 _UNSAFE_WARNING = (
     "WARNING: Gemini CLI is running with permissive approval mode that allows "
     "local file/env access without confirmation. This is unsafe with untrusted inputs."
@@ -60,7 +67,7 @@ _ENV_ALLOWLIST = {
 class GeminiCLIProvider(ProviderAdapter):
     """Gemini CLI provider adapter."""
 
-    name: ClassVar[str] = "gemini-cli"
+    name: ClassVar[str] = "gemini"
     capabilities: ClassVar[ProviderCapabilities] = ProviderCapabilities(
         streaming=False,
         tool_use=False,
@@ -78,8 +85,18 @@ class GeminiCLIProvider(ProviderAdapter):
     ) -> None:
         self._cli_path = cli_path or shutil.which("gemini")
         self._default_model = default_model or DEFAULT_MODEL
-        self._approval_mode = approval_mode or DEFAULT_APPROVAL_MODE
+        self._approval_mode = self._normalize_approval_mode(approval_mode)
         self._timeout = timeout
+
+    def _normalize_approval_mode(self, approval_mode: str | None) -> str:
+        """Map legacy aliases to current Gemini CLI approval modes."""
+
+        mode = (approval_mode or DEFAULT_APPROVAL_MODE).strip().lower()
+        mode = _APPROVAL_MODE_ALIASES.get(mode, mode)
+        if mode not in _VALID_APPROVAL_MODES:
+            valid = ", ".join(sorted(_VALID_APPROVAL_MODES))
+            raise ValueError(f"Unsupported Gemini approval mode '{approval_mode}'. Use one of: {valid}")
+        return mode
 
     def _check_unsafe_mode(self) -> None:
         """Emit warning if using unsafe permissive approval mode."""
@@ -89,6 +106,11 @@ class GeminiCLIProvider(ProviderAdapter):
     def _get_minimal_env(self) -> dict[str, str]:
         """Get minimal environment with only allowlisted variables."""
         return {k: v for k, v in os.environ.items() if k in _ENV_ALLOWLIST}
+
+    def _request_timeout(self, request: GenerateRequest) -> float:
+        """Return the effective timeout for this request."""
+
+        return float(request.timeout_seconds) if request.timeout_seconds is not None else self._timeout
 
     def _build_command(self, request: GenerateRequest) -> list[str]:
         """Build CLI command as argument list (safe from injection)."""
@@ -127,15 +149,16 @@ class GeminiCLIProvider(ProviderAdapter):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=self._get_minimal_env(),
+            start_new_session=True,
         )
 
+        timeout = self._request_timeout(request)
         try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self._timeout)
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.communicate()
+            await terminate_process_tree(proc)
             raise RuntimeError(
-                f"Gemini CLI timed out after {self._timeout}s. "
+                f"Gemini CLI timed out after {timeout}s. "
                 "Consider increasing timeout or simplifying the task."
             )
 
@@ -182,8 +205,8 @@ class GeminiCLIProvider(ProviderAdapter):
     async def doctor(self) -> DoctorResult:
         if not self._cli_path:
             return DoctorResult(ok=False, message="CLI not found")
-        if not os.environ.get("GEMINI_API_KEY"):
-            return DoctorResult(ok=False, message="GEMINI_API_KEY not set")
+        if not (os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")):
+            return DoctorResult(ok=False, message="GEMINI_API_KEY or GOOGLE_API_KEY not set")
         return DoctorResult(ok=True, message="CLI available")
 
 
@@ -191,7 +214,7 @@ def _register() -> None:
     from llm_council.providers.registry import get_registry
 
     with contextlib.suppress(ValueError):
-        get_registry().register_provider("gemini-cli", GeminiCLIProvider)
+        get_registry().register_provider("gemini", GeminiCLIProvider)
 
 
 _register()

--- a/src/llm_council/providers/cli/gemini.py
+++ b/src/llm_council/providers/cli/gemini.py
@@ -20,7 +20,6 @@ import warnings
 from collections.abc import AsyncIterator
 from typing import ClassVar
 
-from llm_council.providers.cli._subprocess import terminate_process_tree
 from llm_council.providers.base import (
     DoctorResult,
     ErrorType,
@@ -31,6 +30,7 @@ from llm_council.providers.base import (
     classify_error,
     get_billing_help_url,
 )
+from llm_council.providers.cli._subprocess import terminate_process_tree
 
 logger = logging.getLogger(__name__)
 

--- a/src/llm_council/providers/google.py
+++ b/src/llm_council/providers/google.py
@@ -24,6 +24,10 @@ from llm_council.providers.base import (
 
 DEFAULT_MODEL = "gemini-3.1-pro-preview"
 ENV_MODEL = "GOOGLE_MODEL"
+ENV_TIMEOUT_MS = "GOOGLE_TIMEOUT_MS"
+ENV_RETRY_ATTEMPTS = "GOOGLE_RETRY_ATTEMPTS"
+DEFAULT_TIMEOUT_MS = 15000
+DEFAULT_RETRY_ATTEMPTS = 1
 
 # Model prefixes that support structured output with response_schema
 # See: https://ai.google.dev/gemini-api/docs/structured-output
@@ -160,6 +164,8 @@ class GoogleProvider(ProviderAdapter):
         self,
         api_key: str | None = None,
         default_model: str | None = None,
+        timeout_ms: int | None = None,
+        retry_attempts: int | None = None,
     ) -> None:
         """Initialize the Google AI provider.
 
@@ -171,6 +177,20 @@ class GoogleProvider(ProviderAdapter):
             api_key or os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
         )
         self._default_model = default_model or os.environ.get(ENV_MODEL) or DEFAULT_MODEL
+        env_timeout = os.environ.get(ENV_TIMEOUT_MS)
+        self._timeout_ms = (
+            timeout_ms
+            if timeout_ms is not None
+            else int(env_timeout) if env_timeout is not None else DEFAULT_TIMEOUT_MS
+        )
+        env_retry_attempts = os.environ.get(ENV_RETRY_ATTEMPTS)
+        self._retry_attempts = (
+            retry_attempts
+            if retry_attempts is not None
+            else int(env_retry_attempts)
+            if env_retry_attempts is not None
+            else DEFAULT_RETRY_ATTEMPTS
+        )
         self._client: Any = None
 
     def _get_client(self) -> Any:
@@ -190,7 +210,15 @@ class GoogleProvider(ProviderAdapter):
                     "Set GOOGLE_API_KEY or GEMINI_API_KEY environment variable or pass api_key."
                 )
 
-            self._client = genai.Client(api_key=self._api_key)
+            self._client = genai.Client(
+                api_key=self._api_key,
+                http_options=genai.types.HttpOptions(
+                    timeout=self._timeout_ms,
+                    retry_options=genai.types.HttpRetryOptions(
+                        attempts=self._retry_attempts,
+                    ),
+                ),
+            )
         return self._client
 
     async def generate(

--- a/src/llm_council/providers/google.py
+++ b/src/llm_council/providers/google.py
@@ -181,7 +181,9 @@ class GoogleProvider(ProviderAdapter):
         self._timeout_ms = (
             timeout_ms
             if timeout_ms is not None
-            else int(env_timeout) if env_timeout is not None else DEFAULT_TIMEOUT_MS
+            else int(env_timeout)
+            if env_timeout is not None
+            else DEFAULT_TIMEOUT_MS
         )
         env_retry_attempts = os.environ.get(ENV_RETRY_ATTEMPTS)
         self._retry_attempts = (

--- a/src/llm_council/providers/openai.py
+++ b/src/llm_council/providers/openai.py
@@ -226,13 +226,17 @@ class OpenAIProvider(ProviderAdapter):
         self._timeout_seconds = (
             timeout_seconds
             if timeout_seconds is not None
-            else float(env_timeout) if env_timeout is not None else DEFAULT_TIMEOUT_SECONDS
+            else float(env_timeout)
+            if env_timeout is not None
+            else DEFAULT_TIMEOUT_SECONDS
         )
         env_max_retries = os.environ.get(ENV_MAX_RETRIES)
         self._max_retries = (
             max_retries
             if max_retries is not None
-            else int(env_max_retries) if env_max_retries is not None else DEFAULT_MAX_RETRIES
+            else int(env_max_retries)
+            if env_max_retries is not None
+            else DEFAULT_MAX_RETRIES
         )
         self._client: Any = None
 

--- a/src/llm_council/providers/openai.py
+++ b/src/llm_council/providers/openai.py
@@ -23,6 +23,10 @@ from llm_council.providers.base import (
 
 DEFAULT_MODEL = "gpt-5.4"
 ENV_MODEL = "OPENAI_MODEL"
+ENV_TIMEOUT_SECONDS = "OPENAI_TIMEOUT_SECONDS"
+ENV_MAX_RETRIES = "OPENAI_MAX_RETRIES"
+DEFAULT_TIMEOUT_SECONDS = 15.0
+DEFAULT_MAX_RETRIES = 0
 
 # Models that support structured output with json_schema response_format
 # See: https://platform.openai.com/docs/guides/structured-outputs
@@ -207,6 +211,8 @@ class OpenAIProvider(ProviderAdapter):
         self,
         api_key: str | None = None,
         default_model: str | None = None,
+        timeout_seconds: float | None = None,
+        max_retries: int | None = None,
     ) -> None:
         """Initialize the OpenAI provider.
 
@@ -216,6 +222,18 @@ class OpenAIProvider(ProviderAdapter):
         """
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
         self._default_model = default_model or os.environ.get(ENV_MODEL) or DEFAULT_MODEL
+        env_timeout = os.environ.get(ENV_TIMEOUT_SECONDS)
+        self._timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else float(env_timeout) if env_timeout is not None else DEFAULT_TIMEOUT_SECONDS
+        )
+        env_max_retries = os.environ.get(ENV_MAX_RETRIES)
+        self._max_retries = (
+            max_retries
+            if max_retries is not None
+            else int(env_max_retries) if env_max_retries is not None else DEFAULT_MAX_RETRIES
+        )
         self._client: Any = None
 
     def _get_client(self) -> Any:
@@ -235,7 +253,11 @@ class OpenAIProvider(ProviderAdapter):
                     "Set OPENAI_API_KEY environment variable or pass api_key."
                 )
 
-            self._client = AsyncOpenAI(api_key=self._api_key)
+            self._client = AsyncOpenAI(
+                api_key=self._api_key,
+                timeout=self._timeout_seconds,
+                max_retries=self._max_retries,
+            )
         return self._client
 
     async def generate(
@@ -258,6 +280,8 @@ class OpenAIProvider(ProviderAdapter):
             "model": request.model or self._default_model,
             "messages": messages,
         }
+        if request.timeout_seconds is not None:
+            kwargs["timeout"] = request.timeout_seconds
 
         if request.max_tokens is not None:
             model = request.model or self._default_model
@@ -267,7 +291,14 @@ class OpenAIProvider(ProviderAdapter):
             else:
                 kwargs["max_tokens"] = request.max_tokens
         if request.temperature is not None:
-            kwargs["temperature"] = request.temperature
+            model = request.model or self._default_model
+            if self._model_supports_temperature(model):
+                kwargs["temperature"] = request.temperature
+            else:
+                logger.warning(
+                    "Model %s does not support temperature parameter; ignored",
+                    model,
+                )
         if request.top_p is not None:
             kwargs["top_p"] = request.top_p
         if request.stop:
@@ -318,7 +349,7 @@ class OpenAIProvider(ProviderAdapter):
                     effort = "medium"
                 kwargs["reasoning_effort"] = effort
             else:
-                logger.warning(
+                logger.debug(
                     "Model %s does not support reasoning_effort parameter; ignored",
                     model,
                 )
@@ -430,6 +461,14 @@ class OpenAIProvider(ProviderAdapter):
 
         # Check if model starts with any o-series prefix
         return any(model.startswith(prefix) for prefix in REASONING_MODEL_PREFIXES)
+
+    def _model_supports_temperature(self, model: str) -> bool:
+        """Check if a model supports the temperature parameter.
+
+        OpenAI o-series reasoning models reject temperature entirely.
+        """
+
+        return not any(model.startswith(prefix) for prefix in REASONING_MODEL_PREFIXES)
 
     async def supports(self, capability: str) -> bool:
         """Check if the provider supports a capability."""

--- a/src/llm_council/providers/registry.py
+++ b/src/llm_council/providers/registry.py
@@ -16,7 +16,9 @@ _log = logging.getLogger(__name__)
 # Backwards-compatible provider name aliases
 _PROVIDER_ALIASES: dict[str, str] = {
     "vertex": "vertex-ai",
-    "claude": "claude-code",
+    "claude-code": "claude",
+    "codex-cli": "codex",
+    "gemini-cli": "gemini",
 }
 
 
@@ -66,17 +68,21 @@ class ProviderRegistry:
             **kwargs: Forwarded to the adapter constructor
                 (e.g. ``default_model``).
         """
-        normalized = name.strip().lower()
-        if not normalized:
-            raise ValueError("Provider name must be a non-empty string.")
-        # Resolve backwards-compatible aliases
-        normalized = _PROVIDER_ALIASES.get(normalized, normalized)
+        normalized = self.resolve_name(name)
         with self._lock:
             adapter_class = self._providers.get(normalized)
         if adapter_class is None:
             available = ", ".join(self.list_providers())
             raise KeyError(f"Provider '{normalized}' is not registered. Available: [{available}]")
         return adapter_class(**kwargs)
+
+    def resolve_name(self, name: str) -> str:
+        """Resolve a provider name or alias to its canonical registered name."""
+
+        normalized = name.strip().lower()
+        if not normalized:
+            raise ValueError("Provider name must be a non-empty string.")
+        return _PROVIDER_ALIASES.get(normalized, normalized)
 
     def list_providers(self) -> list[str]:
         """Return a sorted list of registered provider names."""

--- a/src/llm_council/providers/vertex.py
+++ b/src/llm_council/providers/vertex.py
@@ -51,12 +51,16 @@ from llm_council.providers.google import (
 DEFAULT_MODEL = "gemini-3.1-pro-preview"
 DEFAULT_LOCATION = "us-central1"
 DEFAULT_CLAUDE_REGION = "global"
+DEFAULT_TIMEOUT_MS = 15000
+DEFAULT_RETRY_ATTEMPTS = 1
 
 # Environment variable names
 ENV_VERTEX_MODEL = "VERTEX_AI_MODEL"
 ENV_ANTHROPIC_MODEL = "ANTHROPIC_MODEL"
 ENV_ANTHROPIC_PROJECT = "ANTHROPIC_VERTEX_PROJECT_ID"
 ENV_CLAUDE_REGION = "CLOUD_ML_REGION"
+ENV_TIMEOUT_MS = "VERTEX_AI_TIMEOUT_MS"
+ENV_RETRY_ATTEMPTS = "VERTEX_AI_RETRY_ATTEMPTS"
 
 # Model prefixes for detection
 CLAUDE_MODEL_PREFIXES = ("claude-",)
@@ -120,6 +124,8 @@ class VertexAIProvider(ProviderAdapter):
         location: str | None = None,
         credentials: Any = None,
         default_model: str | None = None,
+        timeout_ms: int | None = None,
+        retry_attempts: int | None = None,
     ) -> None:
         """Initialize the Vertex AI provider.
 
@@ -153,6 +159,21 @@ class VertexAIProvider(ProviderAdapter):
             self._default_model = vertex_model
         else:
             self._default_model = DEFAULT_MODEL
+
+        env_timeout = os.environ.get(ENV_TIMEOUT_MS)
+        self._timeout_ms = (
+            timeout_ms
+            if timeout_ms is not None
+            else int(env_timeout) if env_timeout is not None else DEFAULT_TIMEOUT_MS
+        )
+        env_retry_attempts = os.environ.get(ENV_RETRY_ATTEMPTS)
+        self._retry_attempts = (
+            retry_attempts
+            if retry_attempts is not None
+            else int(env_retry_attempts)
+            if env_retry_attempts is not None
+            else DEFAULT_RETRY_ATTEMPTS
+        )
 
         # Clients for each model type
         self._gemini_client: Any = None
@@ -190,6 +211,12 @@ class VertexAIProvider(ProviderAdapter):
                 project=self._project,
                 location=self._location,
                 credentials=credentials,
+                http_options=genai.types.HttpOptions(
+                    timeout=self._timeout_ms,
+                    retry_options=genai.types.HttpRetryOptions(
+                        attempts=self._retry_attempts,
+                    ),
+                ),
             )
 
         return self._gemini_client

--- a/src/llm_council/providers/vertex.py
+++ b/src/llm_council/providers/vertex.py
@@ -164,7 +164,9 @@ class VertexAIProvider(ProviderAdapter):
         self._timeout_ms = (
             timeout_ms
             if timeout_ms is not None
-            else int(env_timeout) if env_timeout is not None else DEFAULT_TIMEOUT_MS
+            else int(env_timeout)
+            if env_timeout is not None
+            else DEFAULT_TIMEOUT_MS
         )
         env_retry_attempts = os.environ.get(ENV_RETRY_ATTEMPTS)
         self._retry_attempts = (

--- a/src/llm_council/registry/__init__.py
+++ b/src/llm_council/registry/__init__.py
@@ -5,6 +5,6 @@ Provides declarative tool registration and thin base agent abstraction.
 """
 
 from llm_council.registry.base_agent import BaseAgent
-from llm_council.registry.tool_registry import Tool, ToolRegistry
+from llm_council.registry.tool_registry import CapabilityPack, Tool, ToolRegistry
 
-__all__ = ["Tool", "ToolRegistry", "BaseAgent"]
+__all__ = ["Tool", "CapabilityPack", "ToolRegistry", "BaseAgent"]

--- a/src/llm_council/registry/base_agent.py
+++ b/src/llm_council/registry/base_agent.py
@@ -139,6 +139,7 @@ class BaseAgent(ABC):
     def add_tools_from_registry(self, role: str | None = None) -> None:
         """Load tools from registry for this agent's role."""
         registry = get_tool_registry()
+        registry.ensure_loaded()
         role_tools = registry.get_tools_for_role(role or self.ROLE_NAME)
         self._tools.extend(role_tools)
 

--- a/src/llm_council/registry/tool_registry.py
+++ b/src/llm_council/registry/tool_registry.py
@@ -18,6 +18,11 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CONFIG_CANDIDATES = (
+    Path(__file__).resolve().parents[3] / "config" / "tool_registry.yaml",
+    Path.cwd() / "config" / "tool_registry.yaml",
+)
+
 
 @dataclass
 class ToolParameter:
@@ -93,6 +98,17 @@ class Tool:
         }
 
 
+@dataclass
+class CapabilityPack:
+    """Named bundle of tools and evidence expectations."""
+
+    name: str
+    description: str
+    tools: list[str] = field(default_factory=list)
+    roles: list[str] = field(default_factory=list)
+    evidence_requirements: list[str] = field(default_factory=list)
+
+
 class ToolRegistry:
     """
     Registry for declarative tool definitions.
@@ -120,6 +136,7 @@ class ToolRegistry:
 
     def __init__(self) -> None:
         self._tools: dict[str, Tool] = {}
+        self._capability_packs: dict[str, CapabilityPack] = {}
         self._loaded = False
 
     @classmethod
@@ -138,12 +155,20 @@ class ToolRegistry:
         try:
             data = yaml.safe_load(config_path.read_text()) or {}
             tools_data = data.get("tools", {})
+            packs_data = data.get("capability_packs", {})
 
             for tool_name, tool_config in tools_data.items():
                 self.register_tool(self._parse_tool(tool_name, tool_config))
+            for pack_name, pack_config in packs_data.items():
+                self.register_capability_pack(self._parse_capability_pack(pack_name, pack_config))
 
             self._loaded = True
-            logger.info(f"Loaded {len(self._tools)} tools from {config_path}")
+            logger.info(
+                "Loaded %d tools and %d capability packs from %s",
+                len(self._tools),
+                len(self._capability_packs),
+                config_path,
+            )
 
         except (yaml.YAMLError, OSError) as e:
             logger.error(f"Failed to load tool registry: {e}")
@@ -178,14 +203,36 @@ class ToolRegistry:
             handler=config.get("handler"),
         )
 
+    def _parse_capability_pack(self, name: str, config: dict[str, Any]) -> CapabilityPack:
+        """Parse capability pack configuration into CapabilityPack object."""
+
+        return CapabilityPack(
+            name=config.get("name", name),
+            description=config.get("description", ""),
+            tools=list(config.get("tools", [])),
+            roles=list(config.get("roles", [])),
+            evidence_requirements=list(config.get("evidence_requirements", [])),
+        )
+
     def register_tool(self, tool: Tool) -> None:
         """Register a tool in the registry."""
         self._tools[tool.name] = tool
         logger.debug(f"Registered tool: {tool.name}")
 
+    def register_capability_pack(self, pack: CapabilityPack) -> None:
+        """Register a capability pack in the registry."""
+
+        self._capability_packs[pack.name] = pack
+        logger.debug("Registered capability pack: %s", pack.name)
+
     def get_tool(self, name: str) -> Tool | None:
         """Get a tool by name."""
         return self._tools.get(name)
+
+    def get_capability_pack(self, name: str) -> CapabilityPack | None:
+        """Get a capability pack by name."""
+
+        return self._capability_packs.get(name)
 
     def get_tools_for_role(self, role: str) -> list[Tool]:
         """Get all tools available to a specific role."""
@@ -194,6 +241,56 @@ class ToolRegistry:
     def get_all_tools(self) -> list[Tool]:
         """Get all registered tools."""
         return list(self._tools.values())
+
+    def list_capability_packs(self) -> list[str]:
+        """Return the registered capability pack names."""
+
+        return sorted(self._capability_packs.keys())
+
+    def resolve_capability_tools(self, pack_names: list[str], role: str | None = None) -> list[Tool]:
+        """Resolve tools referenced by capability packs."""
+
+        resolved: list[Tool] = []
+        seen: set[str] = set()
+
+        for pack_name in pack_names:
+            pack = self.get_capability_pack(pack_name)
+            if pack is None:
+                logger.debug("Capability pack not found: %s", pack_name)
+                continue
+            if role and pack.roles and role not in pack.roles:
+                continue
+
+            for tool_name in pack.tools:
+                tool = self.get_tool(tool_name)
+                if tool is None:
+                    logger.debug("Tool %s referenced by capability pack %s is not registered", tool_name, pack_name)
+                    continue
+                if role and tool.roles and role not in tool.roles:
+                    continue
+                if tool.name in seen:
+                    continue
+                resolved.append(tool)
+                seen.add(tool.name)
+
+        return resolved
+
+    def ensure_loaded(self, config_path: Path | None = None) -> None:
+        """Load registry data on first use if it has not been loaded yet."""
+
+        if self._loaded:
+            return
+
+        if config_path is not None:
+            self.load_from_yaml(config_path)
+            return
+
+        for candidate in DEFAULT_CONFIG_CANDIDATES:
+            if candidate.exists():
+                self.load_from_yaml(candidate)
+                return
+
+        logger.debug("No default tool registry config found; registry remains empty.")
 
     def to_openai_tools(self, role: str | None = None) -> list[dict[str, Any]]:
         """Convert tools to OpenAI format, optionally filtered by role."""

--- a/src/llm_council/registry/tool_registry.py
+++ b/src/llm_council/registry/tool_registry.py
@@ -191,9 +191,7 @@ class ToolRegistry:
                 )
             else:
                 # Simple type shorthand: "query: string"
-                parameters.append(
-                    ToolParameter(name=param_name, type=str(param_config))
-                )
+                parameters.append(ToolParameter(name=param_name, type=str(param_config)))
 
         return Tool(
             name=config.get("name", name),
@@ -247,7 +245,9 @@ class ToolRegistry:
 
         return sorted(self._capability_packs.keys())
 
-    def resolve_capability_tools(self, pack_names: list[str], role: str | None = None) -> list[Tool]:
+    def resolve_capability_tools(
+        self, pack_names: list[str], role: str | None = None
+    ) -> list[Tool]:
         """Resolve tools referenced by capability packs."""
 
         resolved: list[Tool] = []
@@ -264,7 +264,11 @@ class ToolRegistry:
             for tool_name in pack.tools:
                 tool = self.get_tool(tool_name)
                 if tool is None:
-                    logger.debug("Tool %s referenced by capability pack %s is not registered", tool_name, pack_name)
+                    logger.debug(
+                        "Tool %s referenced by capability pack %s is not registered",
+                        tool_name,
+                        pack_name,
+                    )
                     continue
                 if role and tool.roles and role not in tool.roles:
                     continue

--- a/src/llm_council/schemas/router.json
+++ b/src/llm_council/schemas/router.json
@@ -40,6 +40,32 @@
       "enum": ["deep_reasoner", "fast_generator", "grounded", "code_specialist_normal", "code_specialist_complex", "harsh_critic"],
       "description": "Recommended model pack for this task"
     },
+    "execution_profile": {
+      "type": "string",
+      "enum": ["prompt_only", "light_tools", "grounded", "deep_analysis"],
+      "description": "Recommended execution profile for this task"
+    },
+    "budget_class": {
+      "type": "string",
+      "enum": ["cheap", "normal", "premium"],
+      "description": "Recommended budget level for the routed task"
+    },
+    "required_capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "repo-analysis",
+          "docs-research",
+          "planning-assess",
+          "security-audit",
+          "security-code-audit",
+          "red-team-recon",
+          "diff-review"
+        ]
+      },
+      "description": "Capability packs required before making high-confidence claims"
+    },
     "reasoning": {
       "type": "string",
       "minLength": 20,

--- a/src/llm_council/subagents/__init__.py
+++ b/src/llm_council/subagents/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import yaml
 from pydantic import BaseModel, Field
@@ -156,7 +156,9 @@ def list_subagents() -> list[str]:
     return [p.stem for p in SUBAGENTS_DIR.glob("*.yaml")]
 
 
-def _merge_config_dicts(base: dict[str, Any] | None, override: dict[str, Any] | None) -> dict[str, Any]:
+def _merge_config_dicts(
+    base: dict[str, Any] | None, override: dict[str, Any] | None
+) -> dict[str, Any]:
     """Merge shallow config dictionaries with override precedence."""
 
     merged: dict[str, Any] = {}
@@ -206,10 +208,15 @@ def get_effective_schema(config: dict[str, Any], mode: str | None = None) -> str
 
     resolved_mode = resolve_mode(config, mode)
     if resolved_mode and "modes" in config:
-        mode_config = config["modes"].get(resolved_mode, {})
-        if "schema" in mode_config:
-            return mode_config["schema"]
-    return config.get("schema")
+        modes = config.get("modes")
+        if isinstance(modes, dict):
+            mode_config = modes.get(resolved_mode, {})
+            if isinstance(mode_config, dict):
+                schema = mode_config.get("schema")
+                if isinstance(schema, str):
+                    return schema
+    schema = config.get("schema")
+    return schema if isinstance(schema, str) else None
 
 
 def get_effective_system_prompt(config: dict[str, Any], mode: str | None = None) -> str:
@@ -324,7 +331,9 @@ def get_model_for_subagent(
     Returns:
         OpenRouter-format model ID (e.g., 'anthropic/claude-opus-4-6').
     """
-    pack = normalize_model_pack(model_pack) if model_pack is not None else get_model_pack(config, mode)
+    pack = (
+        normalize_model_pack(model_pack) if model_pack is not None else get_model_pack(config, mode)
+    )
     return get_model_for_pack(pack)
 
 
@@ -338,7 +347,11 @@ def get_mode_config(config: dict[str, Any], mode: str) -> dict[str, Any]:
     Returns:
         Mode configuration dict, or empty dict if mode not found.
     """
-    return config.get("modes", {}).get(mode, {})
+    modes = config.get("modes")
+    if not isinstance(modes, dict):
+        return {}
+    mode_config = modes.get(mode, {})
+    return cast(dict[str, Any], mode_config) if isinstance(mode_config, dict) else {}
 
 
 __all__ = [

--- a/src/llm_council/subagents/__init__.py
+++ b/src/llm_council/subagents/__init__.py
@@ -12,6 +12,8 @@ Supports per-subagent configuration for:
 - Model packs (maps to specific models)
 """
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 from typing import Any, Literal
@@ -20,8 +22,9 @@ import yaml
 from pydantic import BaseModel, Field
 
 from llm_council.config.models import (
-    DEFAULT_MODEL_PACKS,
     ModelPack,
+    get_model_for_pack,
+    normalize_model_pack,
     resolve_model_pack,
 )
 
@@ -153,22 +156,94 @@ def list_subagents() -> list[str]:
     return [p.stem for p in SUBAGENTS_DIR.glob("*.yaml")]
 
 
-def get_provider_preferences(config: dict[str, Any]) -> ProviderPreferences | None:
-    """Extract provider preferences from a subagent config.
+def _merge_config_dicts(base: dict[str, Any] | None, override: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge shallow config dictionaries with override precedence."""
+
+    merged: dict[str, Any] = {}
+    if isinstance(base, dict):
+        merged.update(base)
+    if isinstance(override, dict):
+        merged.update(override)
+    return merged
+
+
+def resolve_mode(config: dict[str, Any], mode: str | None = None) -> str | None:
+    """Resolve the active mode for a subagent configuration.
 
     Args:
         config: Loaded subagent YAML configuration.
+        mode: Optional requested mode.
 
     Returns:
-        ProviderPreferences if 'providers' key exists, None otherwise.
+        Resolved mode name or None if the subagent is mode-less.
+
+    Raises:
+        ValueError: If the requested mode is not defined for the subagent.
     """
-    providers_data = config.get("providers")
+
+    modes = config.get("modes", {})
+    if not modes:
+        return mode
+
+    if mode:
+        if mode not in modes:
+            valid = ", ".join(sorted(modes.keys()))
+            raise ValueError(f"Invalid mode '{mode}'. Valid modes: {valid}")
+        return mode
+
+    default_mode = config.get("default_mode")
+    if isinstance(default_mode, str):
+        if default_mode not in modes:
+            valid = ", ".join(sorted(modes.keys()))
+            raise ValueError(f"Invalid default_mode '{default_mode}'. Valid modes: {valid}")
+        return default_mode
+
+    return None
+
+
+def get_effective_schema(config: dict[str, Any], mode: str | None = None) -> str | None:
+    """Get the effective schema name for a subagent and mode."""
+
+    resolved_mode = resolve_mode(config, mode)
+    if resolved_mode and "modes" in config:
+        mode_config = config["modes"].get(resolved_mode, {})
+        if "schema" in mode_config:
+            return mode_config["schema"]
+    return config.get("schema")
+
+
+def get_effective_system_prompt(config: dict[str, Any], mode: str | None = None) -> str:
+    """Get the effective system prompt, including mode-specific additions."""
+
+    prompts = config.get("prompts", {})
+    parts: list[str] = []
+    system_prompt = prompts.get("system")
+    if isinstance(system_prompt, str) and system_prompt.strip():
+        parts.append(system_prompt.strip())
+
+    resolved_mode = resolve_mode(config, mode)
+    if resolved_mode:
+        mode_prompt = prompts.get("mode_prompts", {}).get(resolved_mode)
+        if isinstance(mode_prompt, str) and mode_prompt.strip():
+            parts.append(mode_prompt.strip())
+
+    return "\n\n".join(parts)
+
+
+def get_provider_preferences(
+    config: dict[str, Any], mode: str | None = None
+) -> ProviderPreferences | None:
+    """Extract provider preferences from a subagent config, including mode overrides."""
+
+    resolved_mode = resolve_mode(config, mode)
+    mode_config = get_mode_config(config, resolved_mode) if resolved_mode else {}
+    providers_data = _merge_config_dicts(config.get("providers"), mode_config.get("providers"))
     if providers_data:
         return ProviderPreferences(**providers_data)
     return None
 
 
-def get_model_overrides(config: dict[str, Any]) -> ModelOverrides | None:
+def get_model_overrides(config: dict[str, Any], mode: str | None = None) -> ModelOverrides | None:
     """Extract model overrides from a subagent config.
 
     Args:
@@ -177,13 +252,15 @@ def get_model_overrides(config: dict[str, Any]) -> ModelOverrides | None:
     Returns:
         ModelOverrides if 'models' key exists, None otherwise.
     """
-    models_data = config.get("models")
+    resolved_mode = resolve_mode(config, mode)
+    mode_config = get_mode_config(config, resolved_mode) if resolved_mode else {}
+    models_data = _merge_config_dicts(config.get("models"), mode_config.get("models"))
     if models_data:
         return ModelOverrides(**models_data)
     return None
 
 
-def get_reasoning_budget(config: dict[str, Any]) -> ReasoningBudget | None:
+def get_reasoning_budget(config: dict[str, Any], mode: str | None = None) -> ReasoningBudget | None:
     """Extract reasoning budget from a subagent config.
 
     Args:
@@ -192,7 +269,9 @@ def get_reasoning_budget(config: dict[str, Any]) -> ReasoningBudget | None:
     Returns:
         ReasoningBudget if 'reasoning' key exists, None otherwise.
     """
-    reasoning_data = config.get("reasoning")
+    resolved_mode = resolve_mode(config, mode)
+    mode_config = get_mode_config(config, resolved_mode) if resolved_mode else {}
+    reasoning_data = _merge_config_dicts(config.get("reasoning"), mode_config.get("reasoning"))
     if reasoning_data:
         return ReasoningBudget(**reasoning_data)
     return None
@@ -233,18 +312,20 @@ def get_model_pack(config: dict[str, Any], mode: str | None = None) -> ModelPack
 def get_model_for_subagent(
     config: dict[str, Any],
     mode: str | None = None,
+    model_pack: str | ModelPack | None = None,
 ) -> str:
     """Get the default model ID for a subagent based on its model pack.
 
     Args:
         config: Loaded subagent YAML configuration.
         mode: Optional mode for consolidated agents.
+        model_pack: Optional runtime model-pack override.
 
     Returns:
         OpenRouter-format model ID (e.g., 'anthropic/claude-opus-4-6').
     """
-    pack = get_model_pack(config, mode)
-    return DEFAULT_MODEL_PACKS[pack]
+    pack = normalize_model_pack(model_pack) if model_pack is not None else get_model_pack(config, mode)
+    return get_model_for_pack(pack)
 
 
 def get_mode_config(config: dict[str, Any], mode: str) -> dict[str, Any]:
@@ -271,6 +352,9 @@ __all__ = [
     "get_provider_preferences",
     "get_model_overrides",
     "get_reasoning_budget",
+    "resolve_mode",
+    "get_effective_schema",
+    "get_effective_system_prompt",
     # Model pack resolution (v0.5.1)
     "get_model_pack",
     "get_model_for_subagent",

--- a/src/llm_council/subagents/router.yaml
+++ b/src/llm_council/subagents/router.yaml
@@ -34,6 +34,9 @@ prompts:
         complexity: normal
         subagent_to_run: drafter
         mode: impl
+        execution_profile: light_tools
+        budget_class: normal
+        required_capabilities: ["repo-analysis"]
         model_pack: code_specialist_normal
         reasoning: "Standard UI implementation with auth integration"
 
@@ -44,6 +47,9 @@ prompts:
         complexity: normal
         subagent_to_run: critic
         mode: review
+        execution_profile: light_tools
+        budget_class: normal
+        required_capabilities: ["diff-review", "repo-analysis"]
         model_pack: harsh_critic
         reasoning: "Security review requires careful critical analysis"
 
@@ -53,6 +59,10 @@ prompts:
         risk_level: critical
         complexity: complex
         subagent_to_run: planner
+        mode: plan
+        execution_profile: light_tools
+        budget_class: normal
+        required_capabilities: ["planning-assess", "repo-analysis"]
         model_pack: deep_reasoner
         reasoning: "Major architectural change requires thorough planning"
 
@@ -62,6 +72,9 @@ prompts:
         risk_level: low
         complexity: normal
         subagent_to_run: researcher
+        execution_profile: grounded
+        budget_class: normal
+        required_capabilities: ["docs-research"]
         model_pack: grounded
         suggested_tools: ["context7", "web_search"]
         reasoning: "External research task, needs grounding"
@@ -73,6 +86,9 @@ prompts:
         complexity: complex
         subagent_to_run: drafter
         mode: arch
+        execution_profile: light_tools
+        budget_class: normal
+        required_capabilities: ["repo-analysis"]
         model_pack: deep_reasoner
         reasoning: "Foundational architecture decision with long-term impact"
 
@@ -83,6 +99,9 @@ prompts:
         complexity: normal
         subagent_to_run: drafter
         mode: test
+        execution_profile: light_tools
+        budget_class: normal
+        required_capabilities: ["repo-analysis"]
         model_pack: code_specialist_normal
         reasoning: "Test generation for critical financial code"
 
@@ -92,6 +111,8 @@ prompts:
         risk_level: low
         complexity: simple
         subagent_to_run: synthesizer
+        execution_profile: prompt_only
+        budget_class: cheap
         model_pack: fast_generator
         reasoning: "Straightforward documentation task"
 
@@ -102,6 +123,9 @@ prompts:
         complexity: complex
         subagent_to_run: critic
         mode: security
+        execution_profile: deep_analysis
+        budget_class: premium
+        required_capabilities: ["red-team-recon", "security-code-audit", "repo-analysis"]
         model_pack: harsh_critic
         reasoning: "Security adversarial analysis requires thorough critique"
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from llm_council.engine.capabilities import select_capability_plan
 from llm_council.registry.tool_registry import ToolRegistry
 
-
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "tool_registry.yaml"
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -79,7 +79,9 @@ class TestCapabilitySelection:
         ]
         assert "web_search" in plan.tool_names
         assert "context7_lookup" in plan.tool_names
-        assert any("Prefer authoritative" in requirement for requirement in plan.evidence_requirements)
+        assert any(
+            "Prefer authoritative" in requirement for requirement in plan.evidence_requirements
+        )
 
     def test_runtime_overrides_do_not_weaken_plan(self):
         """Lower execution-profile or budget hints should not downgrade the base plan."""

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,131 @@
+"""Tests for capability selection and capability-pack registry loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llm_council.engine.capabilities import select_capability_plan
+from llm_council.registry.tool_registry import ToolRegistry
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "tool_registry.yaml"
+
+
+class TestCapabilitySelection:
+    """Tests for runtime capability planning."""
+
+    def test_select_plan_for_planner_assess(self):
+        """Assess mode should use grounded planning and research capabilities."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        plan = select_capability_plan("planner", "assess", tool_registry=registry)
+
+        assert plan.execution_profile == "grounded"
+        assert plan.budget_class == "premium"
+        assert plan.required_capabilities == ["planning-assess", "docs-research"]
+        assert "create_checklist" in plan.tool_names
+        assert "web_search" in plan.tool_names
+        assert "context7_lookup" in plan.tool_names
+
+    def test_select_plan_for_security(self):
+        """Security mode should resolve deep-analysis security capability packs."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        plan = select_capability_plan("critic", "security", tool_registry=registry)
+
+        assert plan.execution_profile == "deep_analysis"
+        assert plan.required_capabilities == [
+            "red-team-recon",
+            "security-code-audit",
+            "repo-analysis",
+        ]
+        assert "code_analysis" in plan.tool_names
+        assert "grep_search" in plan.tool_names
+        assert "web_search" in plan.tool_names
+        assert any("attack paths" in requirement for requirement in plan.evidence_requirements)
+
+    def test_default_prompt_only_fallback(self):
+        """Unknown subagent/mode combinations should stay prompt-only."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        plan = select_capability_plan("unknown-role", None, tool_registry=registry)
+
+        assert plan.execution_profile == "prompt_only"
+        assert plan.required_capabilities == []
+        assert plan.tool_names == []
+
+    def test_runtime_overrides_strengthen_plan_without_reducing_it(self):
+        """Runtime capability overrides should only strengthen the base plan."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        plan = select_capability_plan(
+            "planner",
+            "plan",
+            tool_registry=registry,
+            requested_execution_profile="grounded",
+            requested_budget_class="premium",
+            requested_capabilities=["docs-research"],
+        )
+
+        assert plan.execution_profile == "grounded"
+        assert plan.budget_class == "premium"
+        assert plan.required_capabilities == [
+            "planning-assess",
+            "repo-analysis",
+            "docs-research",
+        ]
+        assert "web_search" in plan.tool_names
+        assert "context7_lookup" in plan.tool_names
+        assert any("Prefer authoritative" in requirement for requirement in plan.evidence_requirements)
+
+    def test_runtime_overrides_do_not_weaken_plan(self):
+        """Lower execution-profile or budget hints should not downgrade the base plan."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        plan = select_capability_plan(
+            "critic",
+            "security",
+            tool_registry=registry,
+            requested_execution_profile="light_tools",
+            requested_budget_class="cheap",
+            requested_capabilities=["planning-assess"],
+        )
+
+        assert plan.execution_profile == "deep_analysis"
+        assert plan.budget_class == "premium"
+        assert plan.required_capabilities == [
+            "red-team-recon",
+            "security-code-audit",
+            "repo-analysis",
+        ]
+
+
+class TestToolRegistryCapabilityPacks:
+    """Tests for capability pack loading from the registry config."""
+
+    def test_loads_capability_packs(self):
+        """Capability packs should be available after loading the YAML config."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        packs = registry.list_capability_packs()
+
+        assert "repo-analysis" in packs
+        assert "planning-assess" in packs
+        assert "security-audit" in packs
+        assert "security-code-audit" in packs
+        assert "red-team-recon" in packs
+
+    def test_resolve_capability_tools_filters_by_role(self):
+        """Pack resolution should return tools valid for the requested role."""
+        registry = ToolRegistry()
+        registry.load_from_yaml(CONFIG_PATH)
+
+        tools = registry.resolve_capability_tools(["planning-assess"], role="planner")
+
+        assert [tool.name for tool in tools] == ["create_checklist", "read_file", "grep_search"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,7 @@ class TestCLIDoctor:
             mock_provider.doctor = AsyncMock(return_value=mock_doctor_result)
             mock_reg.return_value = mock_registry
 
-            result = runner.invoke(app, ["doctor"])
+            runner.invoke(app, ["doctor"])
 
             # Verify get_provider was called with config kwargs
             mock_registry.get_provider.assert_called_with("openai", default_model="gpt-5.2")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from typer.testing import CliRunner
 
 from llm_council.cli.main import app
+from llm_council.eval_import import ImportedPullRequest
+from llm_council.providers.base import GenerateResponse
 
 runner = CliRunner()
 
@@ -36,6 +38,12 @@ class TestCLIHelp:
         """Test config --help displays correctly."""
         result = runner.invoke(app, ["config", "--help"])
         assert result.exit_code == 0
+
+    def test_eval_help(self):
+        """Test eval help displays correctly."""
+        result = runner.invoke(app, ["eval", "--help"])
+        assert result.exit_code == 0
+        assert "evaluation" in result.stdout.lower() or "dataset" in result.stdout.lower()
 
 
 class TestCLIVersion:
@@ -107,6 +115,111 @@ class TestCLIDoctor:
             result = runner.invoke(app, ["doctor"])
             # With no providers, should show empty table or message
             assert result.exit_code == 0
+
+    def test_doctor_accepts_multiple_provider_filters_and_aliases(self):
+        """Doctor should accept repeated --provider flags and resolve friendly aliases."""
+        with (
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={"output_format": "json"},
+            ),
+            patch("llm_council.providers.registry.get_registry") as mock_reg,
+        ):
+            mock_registry = MagicMock()
+            mock_registry.list_providers.return_value = ["claude", "codex", "gemini"]
+            mock_registry.resolve_name.side_effect = {
+                "codex": "codex",
+                "gemini": "gemini",
+                "claude": "claude",
+            }.get
+
+            def _get_provider(name, **_kwargs):
+                provider = MagicMock()
+                result = MagicMock()
+                result.ok = True
+                result.message = f"{name} ok"
+                result.latency_ms = 1.0
+                provider.doctor = AsyncMock(return_value=result)
+                return provider
+
+            mock_registry.get_provider.side_effect = _get_provider
+            mock_reg.return_value = mock_registry
+
+            result = runner.invoke(
+                app,
+                [
+                    "doctor",
+                    "--provider",
+                    "codex",
+                    "--provider",
+                    "gemini,claude",
+                    "--json",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert '"name": "codex"' in result.stdout
+            assert '"name": "gemini"' in result.stdout
+            assert '"name": "claude"' in result.stdout
+
+    def test_doctor_deep_probe_reports_generation_readiness(self):
+        """Deep doctor should surface whether a provider can answer a trivial prompt."""
+        with (
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={"output_format": "json"},
+            ),
+            patch("llm_council.providers.registry.get_registry") as mock_reg,
+        ):
+            mock_registry = MagicMock()
+            mock_registry.list_providers.return_value = ["codex"]
+            mock_registry.resolve_name.side_effect = {"codex": "codex"}.get
+
+            provider = MagicMock()
+            doctor_result = MagicMock()
+            doctor_result.ok = True
+            doctor_result.message = "Logged in using ChatGPT"
+            doctor_result.latency_ms = None
+            provider.doctor = AsyncMock(return_value=doctor_result)
+            provider.generate = AsyncMock(return_value=GenerateResponse(text="OK", content="OK"))
+            mock_registry.get_provider.return_value = provider
+            mock_reg.return_value = mock_registry
+
+            result = runner.invoke(app, ["doctor", "--provider", "codex", "--deep", "--json"])
+
+            assert result.exit_code == 0
+            assert '"probe_ok": true' in result.stdout
+            assert '"probe_message": "OK"' in result.stdout
+
+    def test_doctor_deep_probe_skips_when_base_health_fails(self):
+        """Deep doctor should not run a probe when the base doctor already failed."""
+        with (
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={"output_format": "json"},
+            ),
+            patch("llm_council.providers.registry.get_registry") as mock_reg,
+        ):
+            mock_registry = MagicMock()
+            mock_registry.list_providers.return_value = ["codex"]
+            mock_registry.resolve_name.side_effect = {"codex": "codex"}.get
+
+            provider = MagicMock()
+            doctor_result = MagicMock()
+            doctor_result.ok = False
+            doctor_result.message = "Not logged in"
+            doctor_result.latency_ms = None
+            provider.doctor = AsyncMock(return_value=doctor_result)
+            provider.generate = AsyncMock()
+            mock_registry.get_provider.return_value = provider
+            mock_reg.return_value = mock_registry
+
+            result = runner.invoke(app, ["doctor", "--provider", "codex", "--deep", "--json"])
+
+            assert result.exit_code == 0
+            assert '"probe_ok": false' in result.stdout
+            assert "Skipped because base doctor failed" in result.stdout
+            provider.generate.assert_not_called()
 
 
 class TestCLIConfig:
@@ -227,6 +340,324 @@ class TestOutputFormatConfig:
             # JSON output should not have rich table header
             if "Provider Status" not in result.stdout:
                 assert "{" in result.stdout or "providers" in result.stdout
+
+
+class TestCLIEvaluate:
+    """Tests for eval command."""
+
+    def test_evaluate_json_output(self, tmp_path):
+        """Eval should emit JSON and exit cleanly when all cases pass."""
+        dataset_path = tmp_path / "dataset.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        report = MagicMock()
+        report.failed_cases = 0
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "total_cases": 1,
+            "passed_cases": 1,
+            "failed_cases": 0,
+            "case_results": [],
+            "mode_scorecards": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load,
+            patch("llm_council.cli.main.run_eval_dataset", new_callable=AsyncMock) as mock_eval,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load.return_value = MagicMock()
+            mock_eval.return_value = report
+
+            result = runner.invoke(app, ["eval", str(dataset_path), "--json"])
+
+        assert result.exit_code == 0
+        assert "\"dataset_name\": \"smoke\"" in result.stdout
+
+    def test_evaluate_fails_when_report_has_failed_cases(self, tmp_path):
+        """Eval should return a non-zero exit code when any case fails."""
+        dataset_path = tmp_path / "dataset.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        report = MagicMock()
+        report.failed_cases = 1
+        report.dataset_name = "smoke"
+        report.passed_cases = 0
+        report.total_cases = 1
+        report.passed_criteria = 1
+        report.total_criteria = 2
+        report.duration_ms = 10
+        report.mode_scorecards = []
+        report.case_results = []
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "total_cases": 1,
+            "passed_cases": 0,
+            "failed_cases": 1,
+            "case_results": [],
+            "mode_scorecards": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load,
+            patch("llm_council.cli.main.run_eval_dataset", new_callable=AsyncMock) as mock_eval,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load.return_value = MagicMock()
+            mock_eval.return_value = report
+
+            result = runner.invoke(app, ["eval", str(dataset_path)])
+
+        assert result.exit_code == 1
+
+    def test_evaluate_compare_json_output(self, tmp_path):
+        """Eval-compare should emit JSON and exit cleanly when variants pass."""
+        dataset_path = tmp_path / "dataset.yaml"
+        variants_path = tmp_path / "variants.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        variants_path.write_text("version: 1\nname: candidates\nvariants: []\n")
+        report = MagicMock()
+        report.variant_results = []
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "variants_name": "candidates",
+            "best_variant": None,
+            "ranking": [],
+            "variant_results": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
+            patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
+            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load_dataset.return_value = MagicMock()
+            mock_load_variants.return_value = MagicMock()
+            mock_compare.return_value = report
+
+            result = runner.invoke(
+                app,
+                ["eval-compare", str(dataset_path), str(variants_path), "--json"],
+            )
+
+        assert result.exit_code == 0
+        assert "\"dataset_name\": \"smoke\"" in result.stdout
+
+    def test_evaluate_compare_passes_variant_filters(self, tmp_path):
+        """Eval-compare should forward selected variant names to the runner."""
+        dataset_path = tmp_path / "dataset.yaml"
+        variants_path = tmp_path / "variants.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        variants_path.write_text("version: 1\nname: candidates\nvariants: []\n")
+        report = MagicMock()
+        report.variant_results = []
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "variants_name": "candidates",
+            "best_variant": None,
+            "ranking": [],
+            "variant_results": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
+            patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
+            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load_dataset.return_value = MagicMock()
+            mock_load_variants.return_value = MagicMock()
+            mock_compare.return_value = report
+
+            result = runner.invoke(
+                app,
+                [
+                    "eval-compare",
+                    str(dataset_path),
+                    str(variants_path),
+                    "--variant",
+                    "openai-gpt54",
+                    "--variant",
+                    "vertex-gemini31pro",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert mock_compare.await_args.kwargs["variant_names"] == [
+            "openai-gpt54",
+            "vertex-gemini31pro",
+        ]
+
+    def test_evaluate_compare_builds_base_config_with_timeout_overrides(self, tmp_path):
+        """Eval-compare should honor timeout and retry overrides."""
+        dataset_path = tmp_path / "dataset.yaml"
+        variants_path = tmp_path / "variants.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        variants_path.write_text("version: 1\nname: candidates\nvariants: []\n")
+        report = MagicMock()
+        report.variant_results = []
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "variants_name": "candidates",
+            "best_variant": None,
+            "ranking": [],
+            "variant_results": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
+            patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
+            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load_dataset.return_value = MagicMock()
+            mock_load_variants.return_value = MagicMock()
+            mock_compare.return_value = report
+
+            result = runner.invoke(
+                app,
+                [
+                    "eval-compare",
+                    str(dataset_path),
+                    str(variants_path),
+                    "--timeout",
+                    "30",
+                    "--max-retries",
+                    "1",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        base_config = mock_compare.await_args.kwargs["base_config"]
+        assert base_config.timeout == 30
+        assert base_config.max_retries == 1
+        assert base_config.runtime_profile.value == "default"
+        assert base_config.reasoning_profile.value == "default"
+
+    def test_evaluate_compare_builds_base_config_with_reasoning_profile(self, tmp_path):
+        """Eval-compare should honor reasoning-profile overrides."""
+        dataset_path = tmp_path / "dataset.yaml"
+        variants_path = tmp_path / "variants.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        variants_path.write_text("version: 1\nname: candidates\nvariants: []\n")
+        report = MagicMock()
+        report.variant_results = []
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "variants_name": "candidates",
+            "best_variant": None,
+            "ranking": [],
+            "variant_results": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
+            patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
+            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load_dataset.return_value = MagicMock()
+            mock_load_variants.return_value = MagicMock()
+            mock_compare.return_value = report
+
+            result = runner.invoke(
+                app,
+                [
+                    "eval-compare",
+                    str(dataset_path),
+                    str(variants_path),
+                    "--reasoning-profile",
+                    "off",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        base_config = mock_compare.await_args.kwargs["base_config"]
+        assert base_config.reasoning_profile.value == "off"
+
+    def test_evaluate_compare_builds_base_config_with_runtime_profile(self, tmp_path):
+        """Eval-compare should honor runtime-profile overrides."""
+        dataset_path = tmp_path / "dataset.yaml"
+        variants_path = tmp_path / "variants.yaml"
+        dataset_path.write_text("version: 1\nname: smoke\ncases: []\n")
+        variants_path.write_text("version: 1\nname: candidates\nvariants: []\n")
+        report = MagicMock()
+        report.variant_results = []
+        report.model_dump.return_value = {
+            "dataset_name": "smoke",
+            "variants_name": "candidates",
+            "best_variant": None,
+            "ranking": [],
+            "variant_results": [],
+        }
+
+        with (
+            patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
+            patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
+            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch("llm_council.cli.main._load_config_defaults", return_value={}),
+            patch("llm_council.cli.main._load_provider_configs", return_value={}),
+        ):
+            mock_load_dataset.return_value = MagicMock()
+            mock_load_variants.return_value = MagicMock()
+            mock_compare.return_value = report
+
+            result = runner.invoke(
+                app,
+                [
+                    "eval-compare",
+                    str(dataset_path),
+                    str(variants_path),
+                    "--runtime-profile",
+                    "bounded",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        base_config = mock_compare.await_args.kwargs["base_config"]
+        assert base_config.runtime_profile.value == "bounded"
+
+
+class TestCLIImport:
+    """Tests for local-only PR import command."""
+
+    def test_eval_import_pr_json_output(self):
+        """Import command should emit JSON for the imported bundle."""
+        imported = ImportedPullRequest(
+            repo="owner/repo",
+            pr_number=42,
+            title="Fix auth edge case",
+            state="OPEN",
+            is_draft=False,
+            base_ref="main",
+            head_ref="fix/auth",
+            additions=10,
+            deletions=2,
+            changed_files=1,
+            url="https://github.com/owner/repo/pull/42",
+            import_root=".council-private/imports/github/owner__repo/pr-42",
+            diff_path=".council-private/imports/github/owner__repo/pr-42/diff.patch",
+            review_input_path=".council-private/imports/github/owner__repo/pr-42/review_input.md",
+            metadata_path=".council-private/imports/github/owner__repo/pr-42/pr.json",
+            raw_comments_path=".council-private/imports/github/owner__repo/pr-42/review_comments.raw.json",
+            greptile_labels_path=".council-private/imports/github/owner__repo/pr-42/greptile_labels.json",
+            imported_comment_count=3,
+        )
+
+        with patch("llm_council.cli.main.import_github_pr_review", return_value=imported):
+            result = runner.invoke(app, ["eval-import-pr", "owner/repo", "42", "--json"])
+
+        assert result.exit_code == 0
+        assert "\"repo\": \"owner/repo\"" in result.stdout
 
 
 class TestProviderConfigLoading:
@@ -367,3 +798,84 @@ class TestCLIRun:
                 )
                 # Should attempt to use specified providers
                 assert result.exit_code in [0, 1]
+
+    def test_run_with_route_flag_forwards_router_followup(self):
+        """--route should enable router follow-up in config and run invocation."""
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output = {"recommendation": "proceed"}
+        mock_result.model_dump.return_value = {
+            "success": True,
+            "output": {"recommendation": "proceed"},
+        }
+        mock_result.validation_errors = None
+        mock_result.execution_plan = None
+        mock_result.routed = False
+        mock_result.routing_decision = None
+
+        with patch("llm_council.Council") as mock_council_class:
+            mock_council = MagicMock()
+            mock_council.run = AsyncMock(return_value=mock_result)
+            mock_council_class.return_value = mock_council
+
+            result = runner.invoke(app, ["run", "router", "Test task", "--route"])
+
+            assert result.exit_code == 0
+            council_config = mock_council_class.call_args.kwargs["config"]
+            assert council_config.follow_router is True
+            mock_council.run.assert_awaited_once_with(
+                task="Test task",
+                subagent="router",
+                follow_router=True,
+            )
+
+    def test_run_with_route_flag_requires_router_subagent(self):
+        """--route is rejected for non-router subagents."""
+        result = runner.invoke(app, ["run", "planner", "Test task", "--route"])
+
+        assert result.exit_code == 1
+        assert "--route can only be used with the router subagent" in result.stdout
+
+    def test_run_forwards_reasoning_profile(self):
+        """Run should pass through the reasoning-profile override."""
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output = {"result": "test"}
+        mock_result.model_dump.return_value = {"success": True, "output": {"result": "test"}}
+        mock_result.validation_errors = None
+
+        with patch("llm_council.Council") as mock_council_class:
+            mock_council = MagicMock()
+            mock_council.run = AsyncMock(return_value=mock_result)
+            mock_council_class.return_value = mock_council
+
+            result = runner.invoke(
+                app,
+                ["run", "router", "Test task", "--reasoning-profile", "light"],
+            )
+
+        assert result.exit_code in [0, 1]
+        council_config = mock_council_class.call_args.kwargs["config"]
+        assert council_config.reasoning_profile.value == "light"
+
+    def test_run_forwards_runtime_profile(self):
+        """Run should pass through the runtime-profile override."""
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output = {"result": "test"}
+        mock_result.model_dump.return_value = {"success": True, "output": {"result": "test"}}
+        mock_result.validation_errors = None
+
+        with patch("llm_council.Council") as mock_council_class:
+            mock_council = MagicMock()
+            mock_council.run = AsyncMock(return_value=mock_result)
+            mock_council_class.return_value = mock_council
+
+            result = runner.invoke(
+                app,
+                ["run", "router", "Test task", "--runtime-profile", "bounded"],
+            )
+
+        assert result.exit_code in [0, 1]
+        council_config = mock_council_class.call_args.kwargs["config"]
+        assert council_config.runtime_profile.value == "bounded"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -372,7 +372,7 @@ class TestCLIEvaluate:
             result = runner.invoke(app, ["eval", str(dataset_path), "--json"])
 
         assert result.exit_code == 0
-        assert "\"dataset_name\": \"smoke\"" in result.stdout
+        assert '"dataset_name": "smoke"' in result.stdout
 
     def test_evaluate_fails_when_report_has_failed_cases(self, tmp_path):
         """Eval should return a non-zero exit code when any case fails."""
@@ -429,7 +429,9 @@ class TestCLIEvaluate:
         with (
             patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
             patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
-            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch(
+                "llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock
+            ) as mock_compare,
             patch("llm_council.cli.main._load_config_defaults", return_value={}),
             patch("llm_council.cli.main._load_provider_configs", return_value={}),
         ):
@@ -443,7 +445,7 @@ class TestCLIEvaluate:
             )
 
         assert result.exit_code == 0
-        assert "\"dataset_name\": \"smoke\"" in result.stdout
+        assert '"dataset_name": "smoke"' in result.stdout
 
     def test_evaluate_compare_passes_variant_filters(self, tmp_path):
         """Eval-compare should forward selected variant names to the runner."""
@@ -464,7 +466,9 @@ class TestCLIEvaluate:
         with (
             patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
             patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
-            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch(
+                "llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock
+            ) as mock_compare,
             patch("llm_council.cli.main._load_config_defaults", return_value={}),
             patch("llm_council.cli.main._load_provider_configs", return_value={}),
         ):
@@ -511,7 +515,9 @@ class TestCLIEvaluate:
         with (
             patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
             patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
-            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch(
+                "llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock
+            ) as mock_compare,
             patch("llm_council.cli.main._load_config_defaults", return_value={}),
             patch("llm_council.cli.main._load_provider_configs", return_value={}),
         ):
@@ -559,7 +565,9 @@ class TestCLIEvaluate:
         with (
             patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
             patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
-            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch(
+                "llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock
+            ) as mock_compare,
             patch("llm_council.cli.main._load_config_defaults", return_value={}),
             patch("llm_council.cli.main._load_provider_configs", return_value={}),
         ):
@@ -602,7 +610,9 @@ class TestCLIEvaluate:
         with (
             patch("llm_council.cli.main.load_eval_dataset") as mock_load_dataset,
             patch("llm_council.cli.main.load_eval_variants") as mock_load_variants,
-            patch("llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock) as mock_compare,
+            patch(
+                "llm_council.cli.main.run_eval_comparison", new_callable=AsyncMock
+            ) as mock_compare,
             patch("llm_council.cli.main._load_config_defaults", return_value={}),
             patch("llm_council.cli.main._load_provider_configs", return_value={}),
         ):
@@ -657,7 +667,7 @@ class TestCLIImport:
             result = runner.invoke(app, ["eval-import-pr", "owner/repo", "42", "--json"])
 
         assert result.exit_code == 0
-        assert "\"repo\": \"owner/repo\"" in result.stdout
+        assert '"repo": "owner/repo"' in result.stdout
 
 
 class TestProviderConfigLoading:

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -193,7 +193,9 @@ class TestCouncilRun:
             )
             assert mock_orch_class.call_args_list[1].kwargs["config"].mode == "assess"
             assert mock_orch_class.call_args_list[1].kwargs["config"].model_pack == "deep_reasoner"
-            assert mock_orch_class.call_args_list[1].kwargs["config"].execution_profile == "grounded"
+            assert (
+                mock_orch_class.call_args_list[1].kwargs["config"].execution_profile == "grounded"
+            )
             assert mock_orch_class.call_args_list[1].kwargs["config"].budget_class == "premium"
             assert mock_orch_class.call_args_list[1].kwargs["config"].required_capabilities == [
                 "planning-assess",

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from llm_council import Council, CouncilConfig, CouncilResult
+from llm_council.protocol.types import ReasoningProfile, RuntimeProfile
 
 
 class TestCouncilInit:
@@ -35,6 +36,52 @@ class TestCouncilInit:
             council = Council(config=config)
             assert council.providers == ["google"]
             assert council.config.timeout == 60
+
+    def test_init_provider_argument_overrides_config_providers(self):
+        """Explicit providers should become the effective provider list."""
+        config = CouncilConfig(providers=["google"])
+        with patch("llm_council.council.Orchestrator"):
+            council = Council(providers=["openai"], config=config)
+
+        assert council.providers == ["openai"]
+
+    def test_init_forwards_runtime_truthfulness_fields(self):
+        """Council forwards mode and request override fields to the orchestrator."""
+        config = CouncilConfig(
+            providers=["openrouter"],
+            mode="security",
+            model_pack="grounded",
+            model_overrides={"openai": "gpt-5.4"},
+            execution_profile="deep_analysis",
+            budget_class="premium",
+            required_capabilities=["security-audit"],
+            disable_local_evidence=True,
+            temperature=0.1,
+            max_tokens=777,
+            runtime_profile=RuntimeProfile.BOUNDED,
+            reasoning_profile=ReasoningProfile.LIGHT,
+            output_schema={"type": "object"},
+            system_context="repo context",
+        )
+
+        with patch("llm_council.council.Orchestrator") as mock_orch_class:
+            council = Council(config=config)
+
+            orch_config = mock_orch_class.call_args.kwargs["config"]
+            assert orch_config.mode == "security"
+            assert orch_config.model_pack == "grounded"
+            assert orch_config.model_overrides == {"openai": "gpt-5.4"}
+            assert orch_config.execution_profile == "deep_analysis"
+            assert orch_config.budget_class == "premium"
+            assert orch_config.required_capabilities == ["security-audit"]
+            assert orch_config.disable_local_evidence is True
+            assert orch_config.temperature == 0.1
+            assert orch_config.max_tokens == 777
+            assert orch_config.runtime_profile == RuntimeProfile.BOUNDED
+            assert orch_config.reasoning_profile == ReasoningProfile.LIGHT
+            assert orch_config.output_schema == {"type": "object"}
+            assert orch_config.system_context == "repo context"
+            assert council.config.follow_router is False
 
 
 class TestCouncilRun:
@@ -96,6 +143,101 @@ class TestCouncilRun:
 
             assert result.success is False
             assert "Schema validation failed" in result.validation_errors
+
+    @pytest.mark.asyncio
+    async def test_run_with_follow_router_executes_routed_subagent(self):
+        """A router run can be followed by the selected subagent and mode."""
+        router_result = CouncilResult(
+            success=True,
+            output={
+                "task_type": "planning",
+                "risk_level": "high",
+                "subagent_to_run": "planner",
+                "mode": "assess",
+                "reasoning": "Assessment is the best fit for this decision task.",
+                "model_pack": "deep_reasoner",
+                "execution_profile": "grounded",
+                "budget_class": "premium",
+                "required_capabilities": ["planning-assess", "docs-research"],
+            },
+            execution_plan={"mode": None, "execution_profile": "prompt_only"},
+        )
+        routed_result = CouncilResult(
+            success=True,
+            output={"recommendation": "proceed"},
+            execution_plan={"mode": "assess", "execution_profile": "grounded"},
+        )
+
+        with patch("llm_council.council.Orchestrator") as mock_orch_class:
+            router_orch = AsyncMock()
+            router_orch.run.return_value = router_result
+            routed_orch = AsyncMock()
+            routed_orch.run.return_value = routed_result
+            mock_orch_class.side_effect = [router_orch, routed_orch]
+
+            council = Council(
+                config=CouncilConfig(
+                    providers=["openrouter"],
+                    follow_router=True,
+                )
+            )
+            result = await council.run(task="Should we build or buy SSO?", subagent="router")
+
+            router_orch.run.assert_awaited_once_with(
+                task="Should we build or buy SSO?",
+                subagent="router",
+            )
+            routed_orch.run.assert_awaited_once_with(
+                task="Should we build or buy SSO?",
+                subagent="planner",
+            )
+            assert mock_orch_class.call_args_list[1].kwargs["config"].mode == "assess"
+            assert mock_orch_class.call_args_list[1].kwargs["config"].model_pack == "deep_reasoner"
+            assert mock_orch_class.call_args_list[1].kwargs["config"].execution_profile == "grounded"
+            assert mock_orch_class.call_args_list[1].kwargs["config"].budget_class == "premium"
+            assert mock_orch_class.call_args_list[1].kwargs["config"].required_capabilities == [
+                "planning-assess",
+                "docs-research",
+            ]
+            assert result.routed is True
+            assert result.routing_decision is not None
+            assert result.routing_decision["subagent_to_run"] == "planner"
+            assert result.execution_plan is not None
+            assert result.execution_plan["routed_via_router"] is True
+            assert result.execution_plan["routing_subagent"] == "planner"
+
+    @pytest.mark.asyncio
+    async def test_run_with_follow_router_requires_router_subagent(self):
+        """follow_router is invalid when the initial subagent is not router."""
+        with patch("llm_council.council.Orchestrator"):
+            council = Council(config=CouncilConfig(providers=["openrouter"], follow_router=True))
+
+        with pytest.raises(ValueError, match="follow_router"):
+            await council.run(task="Plan this work", subagent="planner")
+
+    @pytest.mark.asyncio
+    async def test_run_with_follow_router_returns_router_result_when_no_followup(self):
+        """If the router does not pick a follow-up subagent, the router result is returned."""
+        router_result = CouncilResult(
+            success=True,
+            output={
+                "task_type": "shipping",
+                "risk_level": "low",
+                "subagent_to_run": "router",
+                "reasoning": "No follow-up subagent required.",
+            },
+        )
+
+        with patch("llm_council.council.Orchestrator") as mock_orch_class:
+            router_orch = AsyncMock()
+            router_orch.run.return_value = router_result
+            mock_orch_class.return_value = router_orch
+
+            council = Council(config=CouncilConfig(providers=["openrouter"], follow_router=True))
+            result = await council.run(task="Classify this task", subagent="router")
+
+            assert result is router_result
+            assert mock_orch_class.call_count == 1
 
 
 class TestCouncilDoctor:

--- a/tests/test_eval_import.py
+++ b/tests/test_eval_import.py
@@ -1,0 +1,80 @@
+"""Tests for local-only PR review import helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from llm_council.eval_import import import_github_pr_review
+
+
+class TestEvalImport:
+    """Tests for GitHub PR import into local-only review bundles."""
+
+    def test_import_github_pr_review_writes_bundle(self, tmp_path):
+        """Importer should write diff, metadata, labels, and review input files."""
+        pr_json = {
+            "number": 42,
+            "title": "Fix auth edge case",
+            "body": "## Summary\nFixes a bug.\n<!-- greptile_comment -->hidden<!-- /greptile_comment -->",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "main",
+            "headRefName": "fix/auth",
+            "additions": 10,
+            "deletions": 2,
+            "changedFiles": 1,
+            "url": "https://github.com/acme/app/pull/42",
+        }
+        comments_json = [
+            {
+                "id": 1001,
+                "body": (
+                    '<a href="#"><img alt="P1" src="badge"></a> **Leaky internal error**\n\n'
+                    "Use an opaque 500 response.\n\n"
+                    "```suggestion\nhttp.Error(w, \"internal server error\", http.StatusInternalServerError)\n```"
+                ),
+                "path": "backend/handler.go",
+                "line": 77,
+                "start_line": 77,
+                "user": {"login": "greptile-apps[bot]"},
+            },
+            {
+                "id": 1002,
+                "body": "human comment",
+                "path": "backend/handler.go",
+                "line": 80,
+                "start_line": 80,
+                "user": {"login": "octocat"},
+            },
+        ]
+        diff_text = "diff --git a/a.go b/a.go\n@@ -1 +1 @@\n-old\n+new\n"
+
+        def fake_run(command, check, capture_output, text):
+            joined = " ".join(command)
+            if "pr view" in joined:
+                return CompletedProcess(command, 0, stdout=json.dumps(pr_json), stderr="")
+            if "pulls/owner/repo/pulls/42/comments" in joined:
+                raise AssertionError("unexpected endpoint")
+            if "repos/owner/repo/pulls/42/comments?per_page=100" in joined:
+                return CompletedProcess(command, 0, stdout=json.dumps(comments_json), stderr="")
+            if "pr diff" in joined:
+                return CompletedProcess(command, 0, stdout=diff_text, stderr="")
+            raise AssertionError(f"unexpected command: {joined}")
+
+        with patch("llm_council.eval_import.subprocess.run", side_effect=fake_run):
+            imported = import_github_pr_review("owner/repo", 42, output_root=tmp_path)
+
+        import_root = Path(imported.import_root)
+        assert imported.imported_comment_count == 1
+        assert import_root.exists()
+        assert Path(imported.diff_path).read_text() == diff_text
+        labels = json.loads(Path(imported.greptile_labels_path).read_text())
+        assert labels[0]["severity"] == "P1"
+        assert labels[0]["file_path"] == "backend/handler.go"
+        assert "internal server error" in labels[0]["suggested_code"]
+        review_input = Path(imported.review_input_path).read_text()
+        assert "Fix auth edge case" in review_input
+        assert "hidden" not in review_input

--- a/tests/test_eval_import.py
+++ b/tests/test_eval_import.py
@@ -34,7 +34,7 @@ class TestEvalImport:
                 "body": (
                     '<a href="#"><img alt="P1" src="badge"></a> **Leaky internal error**\n\n'
                     "Use an opaque 500 response.\n\n"
-                    "```suggestion\nhttp.Error(w, \"internal server error\", http.StatusInternalServerError)\n```"
+                    '```suggestion\nhttp.Error(w, "internal server error", http.StatusInternalServerError)\n```'
                 ),
                 "path": "backend/handler.go",
                 "line": 77,

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,461 @@
+"""Tests for dataset-driven evaluation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm_council.engine.orchestrator import CouncilResult
+from llm_council.evaluation import (
+    EvalDataset,
+    EvalReport,
+    EvalVariantsFile,
+    load_eval_dataset,
+    load_eval_variants,
+    run_eval_comparison,
+    run_eval_dataset,
+)
+from llm_council.protocol.types import ReasoningProfile, RuntimeProfile
+
+
+class TestEvalDatasetLoading:
+    """Tests for loading eval datasets from disk."""
+
+    def test_load_eval_dataset_yaml(self, tmp_path):
+        """YAML datasets should load into structured models."""
+        dataset_path = tmp_path / "dataset.yaml"
+        dataset_path.write_text(
+            """
+version: 1
+name: smoke
+cases:
+  - id: planner-plan
+    task: Plan this
+    subagent: planner
+    mode: plan
+    expectations:
+      execution_plan_values:
+        mode: plan
+      output_keys: [objective]
+"""
+        )
+
+        dataset = load_eval_dataset(dataset_path)
+
+        assert isinstance(dataset, EvalDataset)
+        assert dataset.name == "smoke"
+        assert dataset.cases[0].mode_key == "planner:plan"
+        assert dataset._source_path == dataset_path
+
+    def test_load_eval_variants_yaml(self, tmp_path):
+        """Variant files should load into structured models."""
+        variants_path = tmp_path / "variants.yaml"
+        variants_path.write_text(
+            """
+version: 1
+name: compare
+variants:
+  - name: openai-default
+    providers: [openai]
+    provider_configs:
+      openai:
+        default_model: gpt-5.4
+"""
+        )
+
+        variants = load_eval_variants(variants_path)
+
+        assert isinstance(variants, EvalVariantsFile)
+        assert variants.name == "compare"
+        assert variants.variants[0].provider_configs["openai"]["default_model"] == "gpt-5.4"
+
+
+class TestRunEvalDataset:
+    """Tests for eval execution and scorecards."""
+
+    @pytest.mark.asyncio
+    async def test_run_eval_dataset_scores_case_and_mode(self):
+        """Eval should score deterministic expectations and aggregate per mode."""
+        dataset = EvalDataset.model_validate(
+            {
+                "version": 1,
+                "name": "smoke",
+                "cases": [
+                    {
+                        "id": "planner-plan",
+                        "task": "Plan rollout",
+                        "subagent": "planner",
+                        "mode": "plan",
+                        "expectations": {
+                            "execution_plan_values": {
+                                "mode": "plan",
+                                "execution_profile": "light_tools",
+                            },
+                            "required_capabilities": ["planning-assess", "repo-analysis"],
+                            "executed_capabilities": ["planning-assess", "repo-analysis"],
+                            "pending_capabilities": [],
+                            "minimum_evidence_items": 2,
+                            "output_keys": ["objective", "phases", "risks", "success_criteria"],
+                        },
+                    }
+                ],
+            }
+        )
+        council_result = CouncilResult(
+            success=True,
+            output={
+                "objective": "Ship the first scoped milestone safely.",
+                "phases": [{"phase_number": 1, "name": "Phase 1", "tasks": [{}], "deliverables": ["spec"]}],
+                "risks": [{"risk": "scope creep", "severity": "medium", "mitigation": "timebox"}],
+                "success_criteria": ["Milestone shipped"],
+            },
+            duration_ms=42,
+            execution_plan={
+                "mode": "plan",
+                "execution_profile": "light_tools",
+                "required_capabilities": ["planning-assess", "repo-analysis"],
+                "executed_capabilities": ["planning-assess", "repo-analysis"],
+                "pending_capabilities": [],
+                "evidence_items": 2,
+            },
+        )
+
+        with patch("llm_council.evaluation.Council") as mock_council_class:
+            council = MagicMock()
+            council.run = AsyncMock(return_value=council_result)
+            mock_council_class.return_value = council
+
+            report = await run_eval_dataset(dataset)
+
+        assert report.total_cases == 1
+        assert report.passed_cases == 1
+        assert report.case_pass_rate == 1.0
+        assert report.mode_scorecards[0].mode_key == "planner:plan"
+        assert report.mode_scorecards[0].criteria_pass_rate == 1.0
+        orch_config = mock_council_class.call_args.kwargs["config"]
+        assert orch_config.mode == "plan"
+
+    @pytest.mark.asyncio
+    async def test_run_eval_dataset_can_fail_fast(self):
+        """Fail-fast should stop after the first failing case."""
+        dataset = EvalDataset.model_validate(
+            {
+                "version": 1,
+                "name": "smoke",
+                "cases": [
+                    {
+                        "id": "case-one",
+                        "task": "Review this",
+                        "subagent": "critic",
+                        "mode": "review",
+                        "expectations": {"success": True},
+                    },
+                    {
+                        "id": "case-two",
+                        "task": "Research this",
+                        "subagent": "researcher",
+                        "expectations": {"success": True},
+                    },
+                ],
+            }
+        )
+        failing_result = CouncilResult(success=False, output=None, duration_ms=5, execution_plan={})
+
+        with patch("llm_council.evaluation.Council") as mock_council_class:
+            council = MagicMock()
+            council.run = AsyncMock(return_value=failing_result)
+            mock_council_class.return_value = council
+
+            report = await run_eval_dataset(dataset, fail_fast=True)
+
+        assert report.total_cases == 1
+        assert report.failed_cases == 1
+        council.run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_eval_dataset_preserves_failure_diagnostics(self):
+        """Eval case results should keep top-level provider failure details."""
+        dataset = EvalDataset.model_validate(
+            {
+                "version": 1,
+                "name": "smoke",
+                "cases": [
+                    {
+                        "id": "critic-review",
+                        "task": "Review this PR",
+                        "subagent": "critic",
+                        "mode": "review",
+                        "expectations": {"success": True},
+                    }
+                ],
+            }
+        )
+        failed_result = CouncilResult(
+            success=False,
+            error="Council run failed.",
+            provider_errors={"openai": "Provider call aborted: Below minimum required providers (1)"},
+            validation_errors=["Empty synthesis response."],
+            duration_ms=20,
+            execution_plan={},
+        )
+
+        with patch("llm_council.evaluation.Council") as mock_council_class:
+            council = MagicMock()
+            council.run = AsyncMock(return_value=failed_result)
+            mock_council_class.return_value = council
+
+            report = await run_eval_dataset(dataset)
+
+        case_result = report.case_results[0]
+        assert case_result.error == "Council run failed."
+        assert case_result.provider_errors == {
+            "openai": "Provider call aborted: Below minimum required providers (1)"
+        }
+        assert case_result.validation_errors == ["Empty synthesis response."]
+
+    @pytest.mark.asyncio
+    async def test_run_eval_dataset_loads_context_file(self, tmp_path):
+        """Case context files should be loaded relative to the dataset path."""
+        context_path = tmp_path / "context.md"
+        context_path.write_text("## Imported PR Context\npatched diff here\n")
+        dataset_path = tmp_path / "dataset.yaml"
+        dataset_path.write_text(
+            """
+version: 1
+name: smoke
+cases:
+  - id: imported-review
+    task: Review the supplied PR
+    subagent: critic
+    mode: review
+    disable_local_evidence: true
+    context_file: context.md
+    expectations:
+      success: true
+"""
+        )
+        dataset = load_eval_dataset(dataset_path)
+        council_result = CouncilResult(success=True, output={"review_summary": "ok"}, duration_ms=10)
+
+        with patch("llm_council.evaluation.Council") as mock_council_class:
+            council = MagicMock()
+            council.run = AsyncMock(return_value=council_result)
+            mock_council_class.return_value = council
+
+            await run_eval_dataset(dataset)
+
+        orch_config = mock_council_class.call_args.kwargs["config"]
+        assert orch_config.disable_local_evidence is True
+        assert "Imported PR Context" in orch_config.system_context
+
+    @pytest.mark.asyncio
+    async def test_run_eval_dataset_supports_output_contains_any(self):
+        """Weak-label expectations can require a minimum number of clue matches."""
+        dataset = EvalDataset.model_validate(
+            {
+                "version": 1,
+                "name": "weak-labels",
+                "cases": [
+                    {
+                        "id": "critic-review",
+                        "task": "Review this PR",
+                        "subagent": "critic",
+                        "mode": "review",
+                        "expectations": {
+                            "output_contains_any": [
+                                "cloudbuild",
+                                "provisioning failed",
+                                "cache-control",
+                            ],
+                            "minimum_output_contains_any_matches": 2,
+                        },
+                    }
+                ],
+            }
+        )
+        council_result = CouncilResult(
+            success=True,
+            output={
+                "review_summary": "cloudbuild is broken and cache-control is too aggressive",
+                "reasoning": "The cloudbuild deploy flags conflict, and cache-control on icons is too sticky.",
+            },
+            duration_ms=12,
+            execution_plan={},
+        )
+
+        with patch("llm_council.evaluation.Council") as mock_council_class:
+            council = MagicMock()
+            council.run = AsyncMock(return_value=council_result)
+            mock_council_class.return_value = council
+
+            report = await run_eval_dataset(dataset)
+
+        assert report.total_cases == 1
+        assert report.passed_cases == 1
+        criterion = report.case_results[0].criteria[1]
+        assert criterion.name == "output_contains_any"
+        assert criterion.passed is True
+
+    @pytest.mark.asyncio
+    async def test_run_eval_comparison_ranks_variants(self):
+        """Comparison should run all variants and rank them by score."""
+        dataset = EvalDataset.model_validate({"version": 1, "name": "smoke", "cases": []})
+        variants = EvalVariantsFile.model_validate(
+            {
+                "version": 1,
+                "name": "providers",
+                "variants": [
+                    {"name": "openai", "providers": ["openai"]},
+                    {"name": "dual", "providers": ["openai", "google"]},
+                ],
+            }
+        )
+        weak_report = EvalReport(
+            dataset_name="smoke",
+            total_cases=1,
+            passed_cases=0,
+            failed_cases=1,
+            case_pass_rate=0.0,
+            total_criteria=2,
+            passed_criteria=1,
+            criteria_pass_rate=0.5,
+            duration_ms=50,
+            mode_scorecards=[],
+            case_results=[],
+        )
+        strong_report = EvalReport(
+            dataset_name="smoke",
+            total_cases=1,
+            passed_cases=1,
+            failed_cases=0,
+            case_pass_rate=1.0,
+            total_criteria=2,
+            passed_criteria=2,
+            criteria_pass_rate=1.0,
+            duration_ms=80,
+            mode_scorecards=[],
+            case_results=[],
+        )
+
+        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+            mock_run_eval.side_effect = [weak_report, strong_report]
+
+            report = await run_eval_comparison(dataset, variants)
+
+        assert report.best_variant == "dual"
+        assert report.ranking == ["dual", "openai"]
+        assert len(report.variant_results) == 2
+        assert report.variant_results[0].variant_name == "openai"
+
+    @pytest.mark.asyncio
+    async def test_run_eval_comparison_can_filter_variants(self):
+        """Comparison should run only the requested named variants."""
+        dataset = EvalDataset.model_validate({"version": 1, "name": "smoke", "cases": []})
+        variants = EvalVariantsFile.model_validate(
+            {
+                "version": 1,
+                "name": "providers",
+                "variants": [
+                    {"name": "openai", "providers": ["openai"]},
+                    {"name": "vertex", "providers": ["vertex-ai"]},
+                    {"name": "dual", "providers": ["openai", "vertex-ai"]},
+                ],
+            }
+        )
+        passing_report = EvalReport(
+            dataset_name="smoke",
+            total_cases=1,
+            passed_cases=1,
+            failed_cases=0,
+            case_pass_rate=1.0,
+            total_criteria=1,
+            passed_criteria=1,
+            criteria_pass_rate=1.0,
+            duration_ms=10,
+            mode_scorecards=[],
+            case_results=[],
+        )
+
+        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+            mock_run_eval.side_effect = [passing_report, passing_report]
+
+            report = await run_eval_comparison(
+                dataset,
+                variants,
+                variant_names=["vertex", "dual"],
+            )
+
+        assert report.ranking == ["vertex", "dual"]
+        assert [item.variant_name for item in report.variant_results] == ["vertex", "dual"]
+        assert mock_run_eval.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_eval_comparison_variant_can_override_reasoning_profile(self):
+        """Variants can force lighter reasoning for bounded benchmark runs."""
+        dataset = EvalDataset.model_validate({"version": 1, "name": "smoke", "cases": []})
+        variants = EvalVariantsFile.model_validate(
+            {
+                "version": 1,
+                "name": "providers",
+                "variants": [
+                    {"name": "light-openai", "providers": ["openai"], "reasoning_profile": "light"},
+                ],
+            }
+        )
+        passing_report = EvalReport(
+            dataset_name="smoke",
+            total_cases=1,
+            passed_cases=1,
+            failed_cases=0,
+            case_pass_rate=1.0,
+            total_criteria=1,
+            passed_criteria=1,
+            criteria_pass_rate=1.0,
+            duration_ms=10,
+            mode_scorecards=[],
+            case_results=[],
+        )
+
+        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+            mock_run_eval.return_value = passing_report
+
+            await run_eval_comparison(dataset, variants)
+
+        base_config = mock_run_eval.await_args.kwargs["base_config"]
+        assert base_config.reasoning_profile == ReasoningProfile.LIGHT
+
+    @pytest.mark.asyncio
+    async def test_run_eval_comparison_variant_can_override_runtime_profile(self):
+        """Variants can force bounded runtime budgets for benchmark runs."""
+        dataset = EvalDataset.model_validate({"version": 1, "name": "smoke", "cases": []})
+        variants = EvalVariantsFile.model_validate(
+            {
+                "version": 1,
+                "name": "providers",
+                "variants": [
+                    {"name": "bounded-openai", "providers": ["openai"], "runtime_profile": "bounded"},
+                ],
+            }
+        )
+        passing_report = EvalReport(
+            dataset_name="smoke",
+            total_cases=1,
+            passed_cases=1,
+            failed_cases=0,
+            case_pass_rate=1.0,
+            total_criteria=1,
+            passed_criteria=1,
+            criteria_pass_rate=1.0,
+            duration_ms=10,
+            mode_scorecards=[],
+            case_results=[],
+        )
+
+        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+            mock_run_eval.return_value = passing_report
+
+            await run_eval_comparison(dataset, variants)
+
+        base_config = mock_run_eval.await_args.kwargs["base_config"]
+        assert base_config.runtime_profile == RuntimeProfile.BOUNDED

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -106,7 +106,9 @@ class TestRunEvalDataset:
             success=True,
             output={
                 "objective": "Ship the first scoped milestone safely.",
-                "phases": [{"phase_number": 1, "name": "Phase 1", "tasks": [{}], "deliverables": ["spec"]}],
+                "phases": [
+                    {"phase_number": 1, "name": "Phase 1", "tasks": [{}], "deliverables": ["spec"]}
+                ],
                 "risks": [{"risk": "scope creep", "severity": "medium", "mitigation": "timebox"}],
                 "success_criteria": ["Milestone shipped"],
             },
@@ -194,7 +196,9 @@ class TestRunEvalDataset:
         failed_result = CouncilResult(
             success=False,
             error="Council run failed.",
-            provider_errors={"openai": "Provider call aborted: Below minimum required providers (1)"},
+            provider_errors={
+                "openai": "Provider call aborted: Below minimum required providers (1)"
+            },
             validation_errors=["Empty synthesis response."],
             duration_ms=20,
             execution_plan={},
@@ -236,7 +240,9 @@ cases:
 """
         )
         dataset = load_eval_dataset(dataset_path)
-        council_result = CouncilResult(success=True, output={"review_summary": "ok"}, duration_ms=10)
+        council_result = CouncilResult(
+            success=True, output={"review_summary": "ok"}, duration_ms=10
+        )
 
         with patch("llm_council.evaluation.Council") as mock_council_class:
             council = MagicMock()
@@ -338,7 +344,9 @@ cases:
             case_results=[],
         )
 
-        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+        with patch(
+            "llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock
+        ) as mock_run_eval:
             mock_run_eval.side_effect = [weak_report, strong_report]
 
             report = await run_eval_comparison(dataset, variants)
@@ -377,7 +385,9 @@ cases:
             case_results=[],
         )
 
-        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+        with patch(
+            "llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock
+        ) as mock_run_eval:
             mock_run_eval.side_effect = [passing_report, passing_report]
 
             report = await run_eval_comparison(
@@ -417,7 +427,9 @@ cases:
             case_results=[],
         )
 
-        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+        with patch(
+            "llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock
+        ) as mock_run_eval:
             mock_run_eval.return_value = passing_report
 
             await run_eval_comparison(dataset, variants)
@@ -434,7 +446,11 @@ cases:
                 "version": 1,
                 "name": "providers",
                 "variants": [
-                    {"name": "bounded-openai", "providers": ["openai"], "runtime_profile": "bounded"},
+                    {
+                        "name": "bounded-openai",
+                        "providers": ["openai"],
+                        "runtime_profile": "bounded",
+                    },
                 ],
             }
         )
@@ -452,7 +468,9 @@ cases:
             case_results=[],
         )
 
-        with patch("llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock) as mock_run_eval:
+        with patch(
+            "llm_council.evaluation.run_eval_dataset", new_callable=AsyncMock
+        ) as mock_run_eval:
             mock_run_eval.return_value = passing_report
 
             await run_eval_comparison(dataset, variants)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,196 @@
+"""Tests for local capability evidence collection."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_council.engine.capabilities import CapabilityPlan
+from llm_council.engine.evidence import collect_capability_evidence
+
+
+class TestEvidenceCollection:
+    """Tests for bounded local evidence collection."""
+
+    @pytest.mark.asyncio
+    async def test_collects_planning_and_repo_evidence(self, tmp_path):
+        """Planning runs should gather checklist and repo-analysis evidence."""
+        (tmp_path / "src").mkdir()
+        (tmp_path / "docs" / "architecture").mkdir(parents=True)
+        (tmp_path / "src" / "planner.py").write_text("def plan_migration():\n    return True\n")
+        (tmp_path / "README.md").write_text("# Project\n")
+        (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
+        (tmp_path / "docs" / "index.md").write_text("# Docs\n")
+
+        plan = CapabilityPlan(
+            execution_profile="light_tools",
+            budget_class="normal",
+            required_capabilities=["planning-assess", "repo-analysis"],
+        )
+
+        bundle = await collect_capability_evidence(
+            "Plan the migration for planner rollout",
+            "planner",
+            "plan",
+            plan,
+            repo_root=tmp_path,
+        )
+
+        assert bundle.executed_capabilities == ["planning-assess", "repo-analysis"]
+        assert bundle.pending_capabilities == []
+        assert len(bundle.items) == 2
+        prompt_block = bundle.to_prompt_block()
+        assert "Collected Evidence" in prompt_block
+        assert "Planning artifacts" in prompt_block
+
+    @pytest.mark.asyncio
+    async def test_collects_security_matches_and_leaves_unsupported_pending(self, tmp_path):
+        """Legacy security-audit alias should still work and leave unsupported packs pending."""
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "auth.py").write_text(
+            "TOKEN='dev'\n"
+            "def run_auth(password, session):\n"
+            "    return password, session, TOKEN\n"
+        )
+
+        plan = CapabilityPlan(
+            execution_profile="deep_analysis",
+            budget_class="premium",
+            required_capabilities=["security-audit", "docs-research"],
+        )
+
+        bundle = await collect_capability_evidence(
+            "Assess the authentication attack surface",
+            "critic",
+            "security",
+            plan,
+            repo_root=tmp_path,
+        )
+
+        assert bundle.executed_capabilities == ["security-audit"]
+        assert bundle.pending_capabilities == ["docs-research"]
+        assert any(item.capability == "security-audit" for item in bundle.items)
+        assert "Capability packs not executed in this runtime" in bundle.to_prompt_block()
+
+    @pytest.mark.asyncio
+    async def test_collects_split_security_evidence(self, tmp_path):
+        """Split security packs should gather attack-surface and code-audit evidence."""
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "auth.py").write_text(
+            "TOKEN='dev'\n"
+            "router.post('/login')\n"
+            "def run_auth(password, session):\n"
+            "    return password, session, TOKEN\n"
+        )
+
+        plan = CapabilityPlan(
+            execution_profile="deep_analysis",
+            budget_class="premium",
+            required_capabilities=["red-team-recon", "security-code-audit"],
+        )
+
+        bundle = await collect_capability_evidence(
+            "Assess the authentication attack surface",
+            "critic",
+            "security",
+            plan,
+            repo_root=tmp_path,
+        )
+
+        assert bundle.executed_capabilities == ["red-team-recon", "security-code-audit"]
+        assert bundle.pending_capabilities == []
+        assert any(item.capability == "red-team-recon" for item in bundle.items)
+        assert any(item.capability == "security-code-audit" for item in bundle.items)
+
+    @pytest.mark.asyncio
+    async def test_collects_docs_research_for_known_targets(self, tmp_path, monkeypatch):
+        """Docs research should execute when the task maps to supported official docs."""
+        fetched_urls: list[str] = []
+
+        def fake_fetch(url: str) -> tuple[str, str] | None:
+            fetched_urls.append(url)
+            return ("React Docs", "Server and client components guidance.")
+
+        monkeypatch.setattr("llm_council.engine.evidence._fetch_docs_page", fake_fetch)
+
+        plan = CapabilityPlan(
+            execution_profile="grounded",
+            budget_class="normal",
+            required_capabilities=["docs-research"],
+        )
+
+        bundle = await collect_capability_evidence(
+            "Research React server components best practices",
+            "researcher",
+            None,
+            plan,
+            repo_root=tmp_path,
+        )
+
+        assert bundle.executed_capabilities == ["docs-research"]
+        assert bundle.pending_capabilities == []
+        assert fetched_urls == ["https://react.dev/reference/react"]
+        assert bundle.items[0].capability == "docs-research"
+        assert "React Docs" in bundle.items[0].details[0]
+
+    @pytest.mark.asyncio
+    async def test_collects_diff_review_from_git_diff(self, tmp_path, monkeypatch):
+        """Review runs should gather changed-file and hunk evidence from a diff."""
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "src" / "service.py").write_text("def old():\n    return False\n")
+        (tmp_path / "tests" / "test_service.py").write_text("def test_old():\n    assert True\n")
+
+        monkeypatch.setattr(
+            "llm_council.engine.evidence._load_git_diff",
+            lambda repo_root: (
+                "diff --git a/src/service.py b/src/service.py\n"
+                "--- a/src/service.py\n"
+                "+++ b/src/service.py\n"
+                "@@ -1,2 +1,2 @@\n"
+                "-def old():\n"
+                "+def old(flag=True):\n"
+            ),
+        )
+
+        plan = CapabilityPlan(
+            execution_profile="light_tools",
+            budget_class="normal",
+            required_capabilities=["diff-review"],
+        )
+
+        bundle = await collect_capability_evidence(
+            "Review the latest implementation changes",
+            "critic",
+            "review",
+            plan,
+            repo_root=tmp_path,
+        )
+
+        assert bundle.executed_capabilities == ["diff-review"]
+        assert bundle.pending_capabilities == []
+        assert bundle.items[0].capability == "diff-review"
+        assert "Changed files: src/service.py" in bundle.items[0].details[0]
+        assert any("@@ -1,2 +1,2 @@" in detail for detail in bundle.items[0].details)
+        assert any("Likely impacted tests" in detail for detail in bundle.items[0].details)
+
+    @pytest.mark.asyncio
+    async def test_diff_review_stays_pending_without_diff(self, tmp_path, monkeypatch):
+        """Without diff context, diff-review should remain pending."""
+        monkeypatch.setattr("llm_council.engine.evidence._load_git_diff", lambda repo_root: "")
+
+        plan = CapabilityPlan(
+            execution_profile="light_tools",
+            budget_class="normal",
+            required_capabilities=["diff-review"],
+        )
+
+        bundle = await collect_capability_evidence(
+            "Review the pending changes",
+            "critic",
+            "review",
+            plan,
+            repo_root=tmp_path,
+        )
+
+        assert bundle.executed_capabilities == []
+        assert bundle.pending_capabilities == ["diff-review"]

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -47,9 +47,7 @@ class TestEvidenceCollection:
         """Legacy security-audit alias should still work and leave unsupported packs pending."""
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "auth.py").write_text(
-            "TOKEN='dev'\n"
-            "def run_auth(password, session):\n"
-            "    return password, session, TOKEN\n"
+            "TOKEN='dev'\ndef run_auth(password, session):\n    return password, session, TOKEN\n"
         )
 
         plan = CapabilityPlan(

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -32,6 +32,7 @@ class TestModelConfig:
             "COUNCIL_MODEL_FAST",
             "COUNCIL_MODEL_REASONING",
             "COUNCIL_MODEL_CODE",
+            "COUNCIL_MODEL_GROUNDED",
             "COUNCIL_MODEL_CRITIC",
         ]:
             os.environ.pop(key, None)
@@ -333,3 +334,15 @@ class TestSubagentModelPack:
 
         # Should be the FAST pack model (claude-haiku-4-5)
         assert "haiku" in model.lower()
+
+    def test_get_model_for_subagent_honors_pack_env_override(self) -> None:
+        """Subagent model resolution should use pack overrides from environment."""
+        from llm_council.subagents import get_model_for_subagent, load_subagent
+
+        os.environ["COUNCIL_MODEL_GROUNDED"] = "google/custom-grounded"
+        ModelConfig.reset()
+
+        researcher_config = load_subagent("researcher")
+        model = get_model_for_subagent(researcher_config)
+
+        assert model == "google/custom-grounded"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from collections.abc import AsyncIterator
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from llm_council.config.models import ModelPack, get_model_for_pack
 from llm_council.engine.orchestrator import (
     CostEstimate,
     CouncilResult,
@@ -13,6 +17,42 @@ from llm_council.engine.orchestrator import (
     OrchestratorConfig,
     ValidationResult,
 )
+from llm_council.protocol.types import ReasoningProfile, RuntimeProfile
+from llm_council.providers.base import (
+    DoctorResult,
+    GenerateRequest,
+    GenerateResponse,
+    ProviderAdapter,
+    ProviderCapabilities,
+)
+
+
+class CaptureProvider(ProviderAdapter):
+    """Provider stub that captures the last request for assertions."""
+
+    name: ClassVar[str] = "capture"
+    capabilities: ClassVar[ProviderCapabilities] = ProviderCapabilities(
+        streaming=False,
+        tool_use=False,
+        structured_output=True,
+        multimodal=False,
+        max_tokens=4096,
+    )
+
+    def __init__(self) -> None:
+        self.last_request: GenerateRequest | None = None
+
+    async def generate(
+        self, request: GenerateRequest
+    ) -> GenerateResponse | AsyncIterator[GenerateResponse]:
+        self.last_request = request
+        return GenerateResponse(text='{"ok": true}')
+
+    async def supports(self, capability: str) -> bool:
+        return capability == "structured_output"
+
+    async def doctor(self) -> DoctorResult:
+        return DoctorResult(ok=True, message="ok")
 
 
 class TestOrchestratorConfig:
@@ -83,10 +123,12 @@ class TestCouncilResult:
             critique="Good work",
             synthesis_attempts=1,
             duration_ms=5000,
+            execution_plan={"mode": "review"},
         )
         assert result.success is True
         assert result.output == {"data": "test"}
         assert result.synthesis_attempts == 1
+        assert result.execution_plan == {"mode": "review"}
 
     def test_failed_result(self):
         """Test failed council result."""
@@ -204,6 +246,128 @@ class TestOrchestratorValidation:
         assert result.ok is False
         assert "Empty synthesis response" in result.errors[0]
 
+    def test_bounded_draft_prompt_prefers_concise_analysis_over_schema_json(self):
+        """Bounded mode should keep draft prompts lightweight."""
+        config = OrchestratorConfig(
+            mode="review",
+            runtime_profile=RuntimeProfile.BOUNDED,
+            reasoning_profile=ReasoningProfile.OFF,
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["openai"], config=config)
+        orch._prepare_run("critic")
+
+        prompt = orch._format_draft_prompt("Review this pull request.")
+
+        assert "not final JSON" in prompt
+        assert "aligns with the JSON schema" not in prompt
+
+    def test_bounded_critique_prompt_omits_full_schema_dump(self):
+        """Bounded mode should avoid embedding the full schema in critique prompts."""
+        config = OrchestratorConfig(
+            mode="review",
+            runtime_profile=RuntimeProfile.BOUNDED,
+            reasoning_profile=ReasoningProfile.OFF,
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["openai"], config=config)
+        orch._prepare_run("critic")
+
+        prompt = orch._format_critique_prompt(
+            "Review this pull request.",
+            {"openai": "Draft analysis"},
+        )
+
+        assert "Schema (JSON):" not in prompt
+        assert "Do not produce final JSON" in prompt
+
+    def test_format_exception_chain_includes_root_cause(self):
+        """Provider diagnostics should preserve the underlying cause."""
+        config = OrchestratorConfig()
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        try:
+            try:
+                raise TimeoutError("upstream request timed out")
+            except TimeoutError as exc:
+                raise RuntimeError("Provider call aborted: Below minimum required providers (1)") from exc
+        except RuntimeError as exc:
+            text = orch._format_exception_chain(exc)
+
+        assert "Provider call aborted" in text
+        assert "upstream request timed out" in text
+
+    def test_build_reasoning_config_respects_off_profile(self):
+        """Reasoning can be disabled at runtime even when the subagent budget enables it."""
+        config = OrchestratorConfig(reasoning_profile=ReasoningProfile.OFF)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        budget = MagicMock(enabled=True, effort="high", budget_tokens=16384, thinking_level="high")
+
+        assert orch._build_reasoning_config(budget) is None
+
+    def test_build_reasoning_config_light_profile_downshifts_budget(self):
+        """Light reasoning should cap and downshift the resolved provider-agnostic config."""
+        config = OrchestratorConfig(reasoning_profile=ReasoningProfile.LIGHT)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        budget = MagicMock(enabled=True, effort="high", budget_tokens=16384, thinking_level="high")
+
+        reasoning = orch._build_reasoning_config(budget)
+
+        assert reasoning is not None
+        assert reasoning.effort == "low"
+        assert reasoning.budget_tokens == 4096
+        assert reasoning.thinking_level == "low"
+
+    def test_phase_max_tokens_respects_bounded_runtime_profile(self):
+        """Bounded runtime profile should clamp per-phase token budgets."""
+        config = OrchestratorConfig(runtime_profile=RuntimeProfile.BOUNDED)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        assert orch._phase_max_tokens(4000, phase="draft") == 2000
+        assert orch._phase_max_tokens(2000, phase="critique") == 1200
+        assert orch._phase_max_tokens(8000, phase="synthesis") == 3000
+
+    def test_phase_max_tokens_global_override_beats_runtime_profile(self):
+        """Explicit max_tokens should override bounded runtime caps."""
+        config = OrchestratorConfig(runtime_profile=RuntimeProfile.BOUNDED, max_tokens=555)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        assert orch._phase_max_tokens(4000, phase="draft") == 555
+
+    def test_bounded_runtime_profile_clamps_provider_timeouts_and_retries(self):
+        """Bounded runtime should shorten provider waits and disable provider retries."""
+        config = OrchestratorConfig(runtime_profile=RuntimeProfile.BOUNDED, timeout=20)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        assert orch._provider_retry_budget() == 0
+        assert orch._provider_request_timeout_seconds("draft") == 15.0
+        assert orch._provider_request_timeout_seconds("critique") == 10.0
+        assert orch._provider_request_timeout_seconds("synthesis") == 15.0
+
 
 class TestOrchestratorDoctor:
     """Tests for Orchestrator doctor method."""
@@ -218,9 +382,49 @@ class TestOrchestratorDoctor:
             mock_reg.return_value = mock_registry
             orch = Orchestrator(providers=["mock"], config=config)
 
-        results = await orch.doctor()
-        assert "mock" in results
-        assert results["mock"]["ok"] is True
+    @pytest.mark.asyncio
+    async def test_call_provider_records_provider_error_on_abort(self):
+        """Critique/synthesis failures should keep the provider root cause."""
+        config = OrchestratorConfig(enable_graceful_degradation=True)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        adapter = MagicMock()
+        adapter.generate = AsyncMock(side_effect=TimeoutError("upstream request timed out"))
+        request = GenerateRequest(prompt="hello")
+
+        with pytest.raises(RuntimeError, match="Provider call aborted"):
+            await orch._call_provider("mock", adapter, request)
+
+        assert "upstream request timed out" in orch._provider_init_errors["mock"]
+        assert "degraded: All providers exhausted" in orch._provider_init_errors["mock"]
+
+    @pytest.mark.asyncio
+    async def test_call_provider_retries_retryable_errors(self):
+        """Retry decisions should actually reattempt the provider call."""
+        config = OrchestratorConfig(enable_graceful_degradation=True)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+
+        adapter = MagicMock()
+        adapter.generate = AsyncMock(
+            side_effect=[
+                TimeoutError("upstream request timed out"),
+                GenerateResponse(text='{"ok": true}'),
+            ]
+        )
+        request = GenerateRequest(prompt="hello")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            response = await orch._call_provider("mock", adapter, request, remaining_providers=1)
+
+        assert response.text == '{"ok": true}'
+        assert adapter.generate.await_count == 2
+        mock_sleep.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_doctor_with_failure(self, failing_provider):
@@ -235,6 +439,520 @@ class TestOrchestratorDoctor:
         results = await orch.doctor()
         assert "mock" in results
         assert results["mock"]["ok"] is False
+
+
+class TestOrchestratorRuntimeTruthfulness:
+    """Tests for mode-aware runtime configuration."""
+
+    def test_prepare_run_resolves_default_mode_and_schema(self):
+        """Critic defaults to review mode and reviewer schema."""
+        config = OrchestratorConfig(runtime_profile=RuntimeProfile.BOUNDED)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("critic")
+
+        assert orch._resolved_mode == "review"
+        assert orch._schema_name == "reviewer"
+        assert orch._schema is not None
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["mode"] == "review"
+        assert orch._execution_plan["schema_name"] == "reviewer"
+        assert orch._execution_plan["execution_profile"] == "light_tools"
+        assert orch._execution_plan["runtime_profile"] == "bounded"
+        assert orch._execution_plan["provider_retry_budget"] == 0
+        assert orch._execution_plan["phase_token_budgets"] == {
+            "draft": 2000,
+            "critique": 1200,
+            "synthesis": 3000,
+        }
+        assert orch._execution_plan["provider_request_timeouts"] == {
+            "draft": 15.0,
+            "critique": 10.0,
+            "synthesis": 15.0,
+        }
+        assert "diff-review" in orch._execution_plan["required_capabilities"]
+
+    def test_prepare_run_applies_mode_prompt(self):
+        """Planner assess mode adds the assess-specific prompt block."""
+        config = OrchestratorConfig(mode="assess")
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("planner")
+
+        assert orch._resolved_mode == "assess"
+        assert orch._schema_name == "assessor"
+        assert "Mode: Decision Assessment" in orch._system_prompt
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["execution_profile"] == "grounded"
+        assert "planning-assess" in orch._execution_plan["required_capabilities"]
+
+    def test_prepare_run_uses_model_pack_override(self):
+        """Runtime model_pack overrides the subagent-selected pack."""
+        config = OrchestratorConfig(mode="assess", model_pack="grounded")
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("planner")
+
+        assert orch._resolved_model_pack == "grounded"
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["model_pack"] == "grounded"
+        assert orch._execution_plan["model_pack_source"] == "config"
+        assert orch._execution_plan["model_overrides"]["openrouter"] == get_model_for_pack(
+            ModelPack.GROUNDED
+        )
+
+    def test_prepare_run_respects_user_default_model_over_subagent_override(self):
+        """Explicit provider default_model should beat mode-specific subagent model overrides."""
+        config = OrchestratorConfig(
+            mode="security",
+            provider_configs={"openai": {"default_model": "gpt-5.4"}},
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        orch._prepare_run("critic")
+
+        assert orch._resolved_mode == "security"
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["model_overrides"]["openai"] == "gpt-5.4"
+
+    def test_prepare_run_runtime_model_pack_beats_subagent_model_override_for_direct_provider(self):
+        """Explicit runtime model_pack should beat mode-specific direct-provider defaults."""
+        config = OrchestratorConfig(mode="security", model_pack="code")
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        orch._prepare_run("critic")
+
+        assert orch._resolved_model_pack == "code"
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["model_overrides"]["openai"] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_auto_fallback_replaces_dead_openrouter_with_configured_direct_provider(self):
+        """Dead default openrouter should fall back to healthy configured direct providers."""
+        config = OrchestratorConfig(
+            mode="security",
+            provider_configs={"openai": {"default_model": "gpt-5.4"}},
+        )
+        dead_openrouter = MagicMock()
+        dead_openrouter.doctor = AsyncMock(
+            return_value=DoctorResult(ok=False, message="OPENROUTER_API_KEY not set")
+        )
+        live_openai = MagicMock()
+        live_openai.doctor = AsyncMock(return_value=DoctorResult(ok=True, message="ok"))
+
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+
+            def get_provider(name, **_kwargs):
+                if name == "openrouter":
+                    return dead_openrouter
+                if name == "openai":
+                    return live_openai
+                raise KeyError(name)
+
+            mock_registry.get_provider.side_effect = get_provider
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("critic")
+        await orch._ensure_usable_providers()
+
+        assert list(orch._providers.keys()) == ["openai"]
+        assert orch._provider_names == ["openai"]
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["providers"] == ["openai"]
+        assert orch._execution_plan["model_overrides"]["openai"] == "gpt-5.4"
+        assert orch._execution_plan["provider_auto_fallback"] == {
+            "from": ["openrouter"],
+            "to": ["openai"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_list_is_not_replaced_by_health_fallback(self):
+        """Explicit user-selected providers must not be swapped for other configured providers."""
+        config = OrchestratorConfig(
+            enable_health_check=True,
+            provider_configs={
+                "openai": {"default_model": "gpt-5.4"},
+                "vertex-ai": {"default_model": "gemini-3.1-pro-preview"},
+            },
+        )
+        dead_openai = MagicMock()
+        dead_openai.doctor = AsyncMock(
+            return_value=DoctorResult(ok=False, message="read timed out")
+        )
+        live_vertex = MagicMock()
+        live_vertex.doctor = AsyncMock(return_value=DoctorResult(ok=True, message="ok"))
+
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+
+            def get_provider(name, **_kwargs):
+                if name == "openai":
+                    return dead_openai
+                if name == "vertex-ai":
+                    return live_vertex
+                raise KeyError(name)
+
+            mock_registry.get_provider.side_effect = get_provider
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        orch._prepare_run("critic")
+        await orch._ensure_usable_providers()
+
+        assert orch._provider_names == ["openai"]
+        assert orch._providers == {}
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["providers"] == ["openai"]
+        assert "provider_auto_fallback" not in orch._execution_plan
+
+    def test_prepare_run_merges_runtime_capability_overrides(self):
+        """Runtime capability overrides should strengthen the resolved capability plan."""
+        config = OrchestratorConfig(
+            mode="plan",
+            execution_profile="grounded",
+            budget_class="premium",
+            required_capabilities=["docs-research"],
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("planner")
+
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["execution_profile"] == "grounded"
+        assert orch._execution_plan["budget_class"] == "premium"
+        assert orch._execution_plan["required_capabilities"] == [
+            "planning-assess",
+            "repo-analysis",
+            "docs-research",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_run_critique_skips_providers_that_failed_earlier(self):
+        """Critique should use only healthy providers when earlier phases failed."""
+        config = OrchestratorConfig()
+        openai_provider = CaptureProvider()
+        vertex_provider = CaptureProvider()
+
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+
+            def get_provider(name, **_kwargs):
+                return {
+                    "openai": openai_provider,
+                    "vertex-ai": vertex_provider,
+                }[name]
+
+            mock_registry.get_provider.side_effect = get_provider
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai", "vertex-ai"], config=config)
+
+        orch._task = "Review this change"
+        orch._prepare_run("critic")
+        orch._provider_init_errors["openai"] = "draft timeout"
+
+        critique = await orch._run_critique({"vertex-ai": '{"draft": "ok"}'})
+
+        assert critique == '{"ok": true}'
+        assert openai_provider.last_request is None
+        assert vertex_provider.last_request is not None
+        assert orch._execution_plan["phase_provider_candidates"]["critique"] == ["vertex-ai"]
+        assert orch._execution_plan["phase_provider_used"]["critique"] == "vertex-ai"
+
+    @pytest.mark.asyncio
+    async def test_run_synthesis_fails_over_to_next_provider(self):
+        """Synthesis should try the next healthy provider when the first one times out."""
+        config = OrchestratorConfig(enable_graceful_degradation=True)
+        openai_provider = MagicMock()
+        openai_provider.supports = AsyncMock(return_value=True)
+        openai_provider.generate = AsyncMock(side_effect=TimeoutError("openai timed out"))
+
+        vertex_provider = MagicMock()
+        vertex_provider.supports = AsyncMock(return_value=True)
+        vertex_provider.generate = AsyncMock(return_value=GenerateResponse(text='{"ok": true}'))
+
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+
+            def get_provider(name, **_kwargs):
+                return {
+                    "openai": openai_provider,
+                    "vertex-ai": vertex_provider,
+                }[name]
+
+            mock_registry.get_provider.side_effect = get_provider
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai", "vertex-ai"], config=config)
+
+        orch._task = "Review this change"
+        orch._subagent_name = "critic"
+        orch._prepare_run("critic")
+        orch._schema = None
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result, attempts = await orch._run_synthesis({"vertex-ai": '{"draft": "ok"}'}, "critique")
+
+        assert result.ok is True
+        assert attempts == 2
+        assert openai_provider.generate.await_count >= 1
+        assert vertex_provider.generate.await_count == 1
+        assert orch._execution_plan["phase_provider_candidates"]["synthesis"] == [
+            "openai",
+            "vertex-ai",
+        ]
+        assert orch._execution_plan["phase_provider_used"]["synthesis"] == "vertex-ai"
+
+    @pytest.mark.asyncio
+    async def test_run_continues_without_critique_when_critique_fails(self):
+        """A critique failure should degrade cleanly and still allow synthesis."""
+        config = OrchestratorConfig(
+            enable_artifacts=False,
+            output_schema={
+                "type": "object",
+                "properties": {"ok": {"type": "boolean"}},
+                "required": ["ok"],
+            },
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = CaptureProvider()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        with (
+            patch.object(
+                orch,
+                "_run_parallel_drafts",
+                AsyncMock(return_value={"openai": '{"ok": true}'}),
+            ),
+            patch.object(
+                orch,
+                "_run_critique",
+                AsyncMock(side_effect=RuntimeError("critique timed out")),
+            ),
+            patch.object(
+                orch,
+                "_run_synthesis",
+                AsyncMock(
+                    return_value=(ValidationResult(ok=True, data={"ok": True}, raw='{"ok": true}'), 1)
+                ),
+            ) as mock_synthesis,
+        ):
+            result = await orch.run("Review this change", "critic")
+
+        assert result.success is True
+        assert result.output == {"ok": True}
+        assert result.execution_plan is not None
+        assert "Critique failed" in result.execution_plan["degradation_notes"][0]
+        mock_synthesis.assert_awaited_once_with({"openai": '{"ok": true}'}, "")
+
+    @pytest.mark.asyncio
+    async def test_run_uses_valid_draft_when_synthesis_fails(self):
+        """A synthesis failure should fall back to a validated draft when possible."""
+        config = OrchestratorConfig(
+            enable_artifacts=False,
+            output_schema={
+                "type": "object",
+                "properties": {"ok": {"type": "boolean"}},
+                "required": ["ok"],
+            },
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = CaptureProvider()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        with (
+            patch.object(
+                orch,
+                "_run_parallel_drafts",
+                AsyncMock(return_value={"openai": '{"ok": true}'}),
+            ),
+            patch.object(orch, "_run_critique", AsyncMock(return_value="critique")),
+            patch.object(
+                orch,
+                "_run_synthesis",
+                AsyncMock(side_effect=RuntimeError("synthesis timed out")),
+            ),
+        ):
+            result = await orch.run("Review this change", "critic")
+
+        assert result.success is True
+        assert result.output == {"ok": True}
+        assert result.synthesis_attempts == 0
+        assert result.validation_errors is not None
+        assert "used validated draft output from openai" in result.validation_errors[0]
+        assert result.execution_plan is not None
+        assert result.execution_plan["degraded_output"]["source"] == "draft"
+        assert result.execution_plan["degraded_output"]["provider"] == "openai"
+
+    def test_prepare_run_uses_custom_output_schema(self):
+        """Custom output_schema overrides subagent schema loading."""
+        custom_schema = {
+            "type": "object",
+            "properties": {"ok": {"type": "boolean"}},
+            "required": ["ok"],
+        }
+        config = OrchestratorConfig(output_schema=custom_schema)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("critic")
+
+        assert orch._schema == custom_schema
+        assert orch._schema_name == "custom"
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["schema_source"] == "custom"
+
+    def test_prepare_run_applies_security_provider_preferences(self):
+        """Security mode narrows the active providers to preferred providers."""
+        config = OrchestratorConfig(mode="security")
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["anthropic", "openai", "google"], config=config)
+
+        orch._prepare_run("critic")
+
+        assert orch._provider_names == ["anthropic", "openai"]
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["providers"] == ["anthropic", "openai"]
+        assert orch._execution_plan["execution_profile"] == "deep_analysis"
+        assert "red-team-recon" in orch._execution_plan["required_capabilities"]
+        assert "security-code-audit" in orch._execution_plan["required_capabilities"]
+
+    @pytest.mark.asyncio
+    async def test_generate_draft_applies_global_overrides_and_reasoning(self):
+        """Draft requests carry resolved temperature/max_tokens/reasoning settings."""
+        config = OrchestratorConfig(
+            mode="security",
+            temperature=0.1,
+            max_tokens=321,
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        orch._prepare_run("critic")
+        orch._task = "Audit this service"
+
+        provider = CaptureProvider()
+        _, _draft = await orch._generate_draft("openai", provider)
+
+        assert provider.last_request is not None
+        assert provider.last_request.temperature == 0.1
+        assert provider.last_request.max_tokens == 321
+        assert provider.last_request.timeout_seconds == 119.0
+        assert provider.last_request.reasoning is not None
+        assert provider.last_request.reasoning.effort == "high"
+        assert provider.last_request.reasoning.budget_tokens == 32768
+        assert provider.last_request.model == "o3-mini"
+
+    @pytest.mark.asyncio
+    async def test_generate_draft_uses_runtime_model_pack_override(self):
+        """Draft requests should use the configured runtime model pack when set."""
+        config = OrchestratorConfig(
+            mode="plan",
+            model_pack="grounded",
+        )
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openrouter"], config=config)
+
+        orch._prepare_run("planner")
+        orch._task = "Assess build versus buy"
+
+        provider = CaptureProvider()
+        _, _draft = await orch._generate_draft("openrouter", provider)
+
+        assert provider.last_request is not None
+        assert provider.last_request.model == get_model_for_pack(ModelPack.GROUNDED)
+
+    @pytest.mark.asyncio
+    async def test_collect_evidence_updates_execution_plan(self, tmp_path, monkeypatch):
+        """Evidence collection should update executed and pending capability telemetry."""
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "auth.py").write_text("TOKEN='x'\npassword='y'\n")
+        monkeypatch.chdir(tmp_path)
+
+        config = OrchestratorConfig(mode="security")
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        orch._task = "Assess auth security"
+        orch._subagent_name = "critic"
+        orch._prepare_run("critic")
+
+        bundle = await orch._collect_evidence_for_run()
+
+        assert bundle.executed_capabilities == [
+            "red-team-recon",
+            "security-code-audit",
+            "repo-analysis",
+        ]
+        assert bundle.pending_capabilities == []
+        assert orch._execution_plan is not None
+        assert orch._execution_plan["executed_capabilities"] == [
+            "red-team-recon",
+            "security-code-audit",
+            "repo-analysis",
+        ]
+        assert orch._execution_plan["evidence_items"] == 3
+
+    def test_format_prompts_include_evidence_requirements_for_capability_modes(self):
+        """Capability-backed modes should carry explicit evidence guidance in prompts."""
+        config = OrchestratorConfig(mode="security")
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_registry = MagicMock()
+            mock_registry.get_provider.return_value = MagicMock()
+            mock_reg.return_value = mock_registry
+            orch = Orchestrator(providers=["openai"], config=config)
+
+        orch._prepare_run("critic")
+        orch._schema = None
+
+        prompt = orch._format_draft_prompt("Audit the authentication system")
+
+        assert "Execution Requirements" in prompt
+        assert "deep_analysis" in prompt
+        assert "If evidence is missing" in prompt
 
 
 class TestOrchestratorPromptFormatting:
@@ -278,6 +996,23 @@ class TestOrchestratorPromptFormatting:
 
         prompt = orch._format_draft_prompt("Build a feature")
         assert "reference_material" not in prompt
+
+    def test_collect_evidence_respects_disable_local_evidence(self):
+        """Local evidence can be disabled for benchmark-style runs."""
+        config = OrchestratorConfig(mode="review", disable_local_evidence=True)
+        with patch("llm_council.engine.orchestrator.get_registry") as mock_reg:
+            mock_reg.return_value = MagicMock()
+            mock_reg.return_value.get_provider.return_value = MagicMock()
+            orch = Orchestrator(providers=["mock"], config=config)
+            orch._task = "Review this change"
+            orch._subagent_name = "critic"
+            orch._prepare_run("critic")
+
+        bundle = asyncio.run(orch._collect_evidence_for_run())
+
+        assert bundle.executed_capabilities == []
+        assert "diff-review" in bundle.pending_capabilities
+        assert orch._execution_plan["local_evidence_disabled"] is True
 
     def test_format_critique_prompt(self):
         """Test critique prompt formatting."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -380,7 +380,7 @@ class TestOrchestratorDoctor:
             mock_registry = MagicMock()
             mock_registry.get_provider.return_value = mock_provider
             mock_reg.return_value = mock_registry
-            orch = Orchestrator(providers=["mock"], config=config)
+            Orchestrator(providers=["mock"], config=config)
 
     @pytest.mark.asyncio
     async def test_call_provider_records_provider_error_on_abort(self):

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -297,7 +297,9 @@ class TestOrchestratorValidation:
             try:
                 raise TimeoutError("upstream request timed out")
             except TimeoutError as exc:
-                raise RuntimeError("Provider call aborted: Below minimum required providers (1)") from exc
+                raise RuntimeError(
+                    "Provider call aborted: Below minimum required providers (1)"
+                ) from exc
         except RuntimeError as exc:
             text = orch._format_exception_chain(exc)
 
@@ -715,7 +717,9 @@ class TestOrchestratorRuntimeTruthfulness:
         orch._schema = None
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result, attempts = await orch._run_synthesis({"vertex-ai": '{"draft": "ok"}'}, "critique")
+            result, attempts = await orch._run_synthesis(
+                {"vertex-ai": '{"draft": "ok"}'}, "critique"
+            )
 
         assert result.ok is True
         assert attempts == 2
@@ -759,7 +763,10 @@ class TestOrchestratorRuntimeTruthfulness:
                 orch,
                 "_run_synthesis",
                 AsyncMock(
-                    return_value=(ValidationResult(ok=True, data={"ok": True}, raw='{"ok": true}'), 1)
+                    return_value=(
+                        ValidationResult(ok=True, data={"ok": True}, raw='{"ok": true}'),
+                        1,
+                    )
                 ),
             ) as mock_synthesis,
         ):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -465,12 +465,18 @@ class TestGeminiCLIProviderDoctor:
     def test_legacy_gemini_approval_modes_are_normalized(self):
         """Legacy Gemini approval aliases should map to current CLI values."""
         assert GeminiCLIProvider(cli_path="/opt/homebrew/bin/gemini")._approval_mode == "default"
-        assert GeminiCLIProvider(
-            cli_path="/opt/homebrew/bin/gemini", approval_mode="confirm"
-        )._approval_mode == "default"
-        assert GeminiCLIProvider(
-            cli_path="/opt/homebrew/bin/gemini", approval_mode="auto"
-        )._approval_mode == "yolo"
+        assert (
+            GeminiCLIProvider(
+                cli_path="/opt/homebrew/bin/gemini", approval_mode="confirm"
+            )._approval_mode
+            == "default"
+        )
+        assert (
+            GeminiCLIProvider(
+                cli_path="/opt/homebrew/bin/gemini", approval_mode="auto"
+            )._approval_mode
+            == "yolo"
+        )
 
     def test_invalid_gemini_approval_mode_raises(self):
         """Unknown Gemini approval modes should fail fast."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from llm_council.providers.anthropic import (
@@ -12,10 +14,12 @@ from llm_council.providers.anthropic import (
 )
 from llm_council.providers.base import (
     DoctorResult,
+    ErrorType,
     GenerateRequest,
     GenerateResponse,
     Message,
     ProviderCapabilities,
+    classify_error,
 )
 from llm_council.providers.google import (
     DEFAULT_MODEL as GOOGLE_DEFAULT_MODEL,
@@ -35,6 +39,10 @@ from llm_council.providers.openrouter import (
 from llm_council.providers.openrouter import (
     OpenRouterProvider,
 )
+from llm_council.providers.cli.gemini import GeminiCLIProvider
+from llm_council.providers.cli.codex import CodexCLIProvider
+from llm_council.providers.cli.claude_code import ClaudeCodeCLIProvider
+from llm_council.providers.vertex import VertexAIProvider
 from llm_council.providers.registry import ProviderRegistry, get_registry
 
 
@@ -195,6 +203,15 @@ class TestProviderRegistry:
         with pytest.raises(KeyError, match="not registered"):
             registry.get_provider("nonexistent")
 
+    def test_aliases_resolve_to_cli_providers(self, mock_registry):
+        """Friendly aliases should resolve to canonical CLI-backed provider names."""
+        assert mock_registry.resolve_name("codex") == "codex"
+        assert mock_registry.resolve_name("gemini") == "gemini"
+        assert mock_registry.resolve_name("claude") == "claude"
+        assert mock_registry.resolve_name("codex-cli") == "codex"
+        assert mock_registry.resolve_name("gemini-cli") == "gemini"
+        assert mock_registry.resolve_name("claude-code") == "claude"
+
     def test_list_providers(self, mock_registry):
         """Test listing registered providers."""
         providers = mock_registry.list_providers()
@@ -213,6 +230,17 @@ class TestProviderRegistry:
         registry1 = get_registry()
         registry2 = get_registry()
         assert registry1 is registry2
+
+
+class TestErrorClassification:
+    """Tests for shared provider error classification."""
+
+    def test_classify_timeout_variants(self):
+        """Timeout-shaped transport errors should classify as retryable timeouts."""
+        assert classify_error("upstream request timed out") == ErrorType.TIMEOUT
+        assert classify_error("The operation did not complete (read timed out)") == (
+            ErrorType.TIMEOUT
+        )
 
 
 class TestMockProvider:
@@ -272,6 +300,110 @@ class TestOpenAIProviderEnvModel:
         assert provider._default_model == "gpt-5.1-mini"
 
 
+class TestOpenAIProviderRequestParams:
+    """Tests for model-specific OpenAI request parameter handling."""
+
+    @pytest.mark.asyncio
+    async def test_o_series_omits_temperature(self):
+        """o-series reasoning models should not receive temperature."""
+        provider = OpenAIProvider(api_key="test-key")
+
+        captured_kwargs: dict[str, object] = {}
+
+        async def create(**kwargs):
+            captured_kwargs.update(kwargs)
+            message = MagicMock(content='{"ok": true}', tool_calls=None)
+            choice = MagicMock(message=message, finish_reason="stop")
+            usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+            return MagicMock(choices=[choice], usage=usage, model="o3-mini")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=create)
+        provider._client = mock_client
+
+        request = GenerateRequest(
+            model="o3-mini",
+            messages=[Message(role="user", content="test")],
+            temperature=0.2,
+            max_tokens=100,
+        )
+
+        await provider.generate(request)
+
+        assert "temperature" not in captured_kwargs
+        assert captured_kwargs["max_completion_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_request_timeout_is_forwarded_to_openai_sdk(self):
+        """Per-request timeout should be forwarded to the OpenAI SDK call."""
+        provider = OpenAIProvider(api_key="test-key")
+
+        captured_kwargs: dict[str, object] = {}
+
+        async def create(**kwargs):
+            captured_kwargs.update(kwargs)
+            message = MagicMock(content='{"ok": true}', tool_calls=None)
+            choice = MagicMock(message=message, finish_reason="stop")
+            usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+            return MagicMock(choices=[choice], usage=usage, model="gpt-5.4")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=create)
+        provider._client = mock_client
+
+        request = GenerateRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="test")],
+            timeout_seconds=19,
+        )
+
+        await provider.generate(request)
+
+        assert captured_kwargs["timeout"] == 19
+
+
+class TestProviderTransportDefaults:
+    """Tests for provider-native timeout and retry configuration."""
+
+    def test_openai_client_disables_sdk_retries_by_default(self, monkeypatch):
+        """OpenAI should use explicit transport timeout and no SDK retries."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with patch("openai.AsyncOpenAI") as mock_client:
+            provider = OpenAIProvider()
+            provider._get_client()
+
+        kwargs = mock_client.call_args.kwargs
+        assert kwargs["timeout"] == 15.0
+        assert kwargs["max_retries"] == 0
+
+    def test_google_client_uses_bounded_http_options(self, monkeypatch):
+        """Google provider should clamp SDK timeout and retry attempts."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
+        with patch("google.genai.Client") as mock_client:
+            provider = GoogleProvider()
+            provider._get_client()
+
+        http_options = mock_client.call_args.kwargs["http_options"]
+        assert http_options.timeout == 15000
+        assert http_options.retry_options.attempts == 1
+
+    def test_vertex_gemini_client_uses_bounded_http_options(self, monkeypatch):
+        """Vertex Gemini client should use the same bounded HTTP settings."""
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+        with patch("google.genai.Client") as mock_client:
+            provider = VertexAIProvider()
+            provider._get_gemini_client()
+
+        kwargs = mock_client.call_args.kwargs
+        http_options = kwargs["http_options"]
+        assert kwargs["vertexai"] is True
+        assert http_options.timeout == 15000
+        assert http_options.retry_options.attempts == 1
+
+
 class TestAnthropicProviderEnvModel:
     """Tests for ANTHROPIC_MODEL env var fallback in AnthropicProvider."""
 
@@ -314,6 +446,125 @@ class TestGoogleProviderEnvModel:
         monkeypatch.setenv("GOOGLE_MODEL", "gemini-2.0-flash")
         provider = GoogleProvider(default_model="gemini-3.1-pro-preview")
         assert provider._default_model == "gemini-3.1-pro-preview"
+
+
+class TestGeminiCLIProviderDoctor:
+    """Tests for Gemini CLI doctor auth checks."""
+
+    @pytest.mark.asyncio
+    async def test_google_api_key_is_enough_for_doctor(self, monkeypatch):
+        """Gemini CLI doctor should accept GOOGLE_API_KEY, not only GEMINI_API_KEY."""
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        provider = GeminiCLIProvider(cli_path="/opt/homebrew/bin/gemini")
+
+        result = await provider.doctor()
+
+        assert result.ok is True
+
+    def test_legacy_gemini_approval_modes_are_normalized(self):
+        """Legacy Gemini approval aliases should map to current CLI values."""
+        assert GeminiCLIProvider(cli_path="/opt/homebrew/bin/gemini")._approval_mode == "default"
+        assert GeminiCLIProvider(
+            cli_path="/opt/homebrew/bin/gemini", approval_mode="confirm"
+        )._approval_mode == "default"
+        assert GeminiCLIProvider(
+            cli_path="/opt/homebrew/bin/gemini", approval_mode="auto"
+        )._approval_mode == "yolo"
+
+    def test_invalid_gemini_approval_mode_raises(self):
+        """Unknown Gemini approval modes should fail fast."""
+        with pytest.raises(ValueError, match="Unsupported Gemini approval mode"):
+            GeminiCLIProvider(cli_path="/opt/homebrew/bin/gemini", approval_mode="invalid")
+
+
+class TestCodexCLIProviderDoctor:
+    """Tests for Codex CLI doctor readiness checks."""
+
+    @pytest.mark.asyncio
+    async def test_codex_doctor_uses_login_status(self):
+        provider = CodexCLIProvider(cli_path="/usr/local/bin/codex")
+        process = AsyncMock()
+        process.communicate.return_value = (b"Logged in using ChatGPT\n", b"")
+        process.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+            result = await provider.doctor()
+
+        assert result.ok is True
+        assert "Logged in using ChatGPT" in result.message
+        mock_exec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_codex_doctor_reports_not_logged_in(self):
+        provider = CodexCLIProvider(cli_path="/usr/local/bin/codex")
+        process = AsyncMock()
+        process.communicate.return_value = (b"Not logged in\n", b"")
+        process.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await provider.doctor()
+
+        assert result.ok is False
+        assert "Not logged in" in result.message
+
+
+class TestCLIProviderTimeouts:
+    """Tests for CLI provider request timeout overrides."""
+
+    def test_codex_cli_uses_request_timeout(self):
+        provider = CodexCLIProvider(cli_path="/Users/kozman/.bun/bin/codex")
+        request = GenerateRequest(prompt="test", timeout_seconds=19)
+        assert provider._request_timeout(request) == 19.0
+
+    def test_gemini_cli_uses_request_timeout(self):
+        provider = GeminiCLIProvider(cli_path="/opt/homebrew/bin/gemini")
+        request = GenerateRequest(prompt="test", timeout_seconds=17)
+        assert provider._request_timeout(request) == 17.0
+
+    def test_claude_code_cli_uses_request_timeout(self):
+        provider = ClaudeCodeCLIProvider(cli_path="/Users/kozman/.local/bin/claude")
+        request = GenerateRequest(prompt="test", timeout_seconds=23)
+        assert provider._request_timeout(request) == 23.0
+
+    @pytest.mark.asyncio
+    async def test_gemini_cli_starts_new_session(self):
+        provider = GeminiCLIProvider(cli_path="/opt/homebrew/bin/gemini")
+        process = AsyncMock()
+        process.communicate.return_value = (b"ok", b"")
+        process.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+            response = await provider.generate(GenerateRequest(prompt="test"))
+
+        assert response.text == "ok"
+        assert mock_exec.await_args.kwargs["start_new_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_codex_cli_starts_new_session(self):
+        provider = CodexCLIProvider(cli_path="/usr/local/bin/codex")
+        process = AsyncMock()
+        process.communicate.return_value = (b"ok", b"")
+        process.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+            response = await provider.generate(GenerateRequest(prompt="test"))
+
+        assert response.text == "ok"
+        assert mock_exec.await_args.kwargs["start_new_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_claude_cli_starts_new_session(self):
+        provider = ClaudeCodeCLIProvider(cli_path="/usr/local/bin/claude")
+        process = AsyncMock()
+        process.communicate.return_value = (b'{"result": "ok"}', b"")
+        process.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec:
+            response = await provider.generate(GenerateRequest(prompt="test"))
+
+        assert response.text == "ok"
+        assert mock_exec.await_args.kwargs["start_new_session"] is True
 
 
 class TestOpenRouterProviderEnvModel:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -369,7 +371,11 @@ class TestProviderTransportDefaults:
         """OpenAI should use explicit transport timeout and no SDK retries."""
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
-        with patch("openai.AsyncOpenAI") as mock_client:
+        openai_module = ModuleType("openai")
+        mock_client = MagicMock()
+        openai_module.AsyncOpenAI = mock_client
+
+        with patch.dict(sys.modules, {"openai": openai_module}):
             provider = OpenAIProvider()
             provider._get_client()
 
@@ -381,7 +387,17 @@ class TestProviderTransportDefaults:
         """Google provider should clamp SDK timeout and retry attempts."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
 
-        with patch("google.genai.Client") as mock_client:
+        google_module = ModuleType("google")
+        genai_module = ModuleType("google.genai")
+        mock_client = MagicMock()
+        genai_module.Client = mock_client
+        genai_module.types = SimpleNamespace(
+            HttpOptions=lambda **kwargs: SimpleNamespace(**kwargs),
+            HttpRetryOptions=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+        google_module.genai = genai_module
+
+        with patch.dict(sys.modules, {"google": google_module, "google.genai": genai_module}):
             provider = GoogleProvider()
             provider._get_client()
 
@@ -393,7 +409,17 @@ class TestProviderTransportDefaults:
         """Vertex Gemini client should use the same bounded HTTP settings."""
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
 
-        with patch("google.genai.Client") as mock_client:
+        google_module = ModuleType("google")
+        genai_module = ModuleType("google.genai")
+        mock_client = MagicMock()
+        genai_module.Client = mock_client
+        genai_module.types = SimpleNamespace(
+            HttpOptions=lambda **kwargs: SimpleNamespace(**kwargs),
+            HttpRetryOptions=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+        google_module.genai = genai_module
+
+        with patch.dict(sys.modules, {"google": google_module, "google.genai": genai_module}):
             provider = VertexAIProvider()
             provider._get_gemini_client()
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -21,6 +21,9 @@ from llm_council.providers.base import (
     ProviderCapabilities,
     classify_error,
 )
+from llm_council.providers.cli.claude_code import ClaudeCodeCLIProvider
+from llm_council.providers.cli.codex import CodexCLIProvider
+from llm_council.providers.cli.gemini import GeminiCLIProvider
 from llm_council.providers.google import (
     DEFAULT_MODEL as GOOGLE_DEFAULT_MODEL,
 )
@@ -39,11 +42,8 @@ from llm_council.providers.openrouter import (
 from llm_council.providers.openrouter import (
     OpenRouterProvider,
 )
-from llm_council.providers.cli.gemini import GeminiCLIProvider
-from llm_council.providers.cli.codex import CodexCLIProvider
-from llm_council.providers.cli.claude_code import ClaudeCodeCLIProvider
-from llm_council.providers.vertex import VertexAIProvider
 from llm_council.providers.registry import ProviderRegistry, get_registry
+from llm_council.providers.vertex import VertexAIProvider
 
 
 class TestProviderCapabilities:

--- a/uv.lock
+++ b/uv.lock
@@ -1262,7 +1262,7 @@ wheels = [
 
 [[package]]
 name = "the-llm-council"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- ship the mode-aware runtime path and routed handoff flow
- add capability planning, evidence collection, deterministic eval tooling, and local-only PR import support
- harden provider/CLI readiness diagnostics and release docs for v0.7.0

## Highlights
- runtime mode, schema, model-pack, runtime-profile, and reasoning-profile now flow through execution
- `council run router ... --route` can continue into the selected subagent/mode
- `council doctor --deep`, `council eval`, `council eval-compare`, and `council eval-import-pr` are public
- explicit user provider/model choices are respected over subagent defaults
- local-only benchmark material is isolated under `.council-private/`
- package version bumped to `0.7.0`

## Verification
- `uv run pytest tests/test_orchestrator.py tests/test_cli.py tests/test_providers.py tests/test_council.py`
- `uv build`
- `python3 -m compileall src/llm_council`
