### PR TITLE
feat(cli): add --format markdown output (v0.7.17)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-council",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Multi-LLM Council for adversarial debate, cross-validation, and structured decision-making",
   "author": {
     "name": "Sherif Kozman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.17] - 2026-06-01
+
+### Added
+- `council run --format <json|markdown>` (alias `md`) renders council results as clean, human-readable Markdown — status heading, Output/Errors, Critique, Metrics, and Routing sections — honored for both stdout and `--output` file writes. Precedence: `--format` > `--json` > config `output_format`; default behavior (rich panel) is unchanged and `--json` now maps to `--format json`.
+
+### Changed
+- Refreshed `CLAUDE.md` to v0.7.17: documented the new `--format` option, corrected the version header, and replaced stale issue references with current state.
+
 ## [0.7.16] - 2026-04-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Multi-LLM Council Framework (v0.7.16) that orchestrates multiple LLM backends for adversarial debate, cross-validation, and structured decision-making. Published as `the-llm-council` on PyPI.
+Multi-LLM Council Framework (v0.7.17) that orchestrates multiple LLM backends for adversarial debate, cross-validation, and structured decision-making. Published as `the-llm-council` on PyPI.
 
 - **Python**: >=3.10 (tested 3.10, 3.11, 3.12)
 - **Build**: hatchling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Multi-LLM Council Framework (v0.6.0) that orchestrates multiple LLM backends for adversarial debate, cross-validation, and structured decision-making. Published as `the-llm-council` on PyPI.
+Multi-LLM Council Framework (v0.7.16) that orchestrates multiple LLM backends for adversarial debate, cross-validation, and structured decision-making. Published as `the-llm-council` on PyPI.
 
 - **Python**: >=3.10 (tested 3.10, 3.11, 3.12)
 - **Build**: hatchling
@@ -120,7 +120,8 @@ council run <subagent> "<task>" [OPTIONS]
 | `--context, --system` | Additional system context/instructions |
 | `--schema` | Custom output schema JSON file |
 | `--no-artifacts` | Disable artifact storage |
-| `--json` | Output structured JSON |
+| `--format` | Output format: `json` or `markdown` (alias `md`). Renders to clean human-readable Markdown on stdout and to `--output` files. Precedence: `--format` > `--json` > config `output_format`; default keeps the rich panel |
+| `--json` | Output structured JSON (shorthand for `--format json`) |
 | `--verbose, -v` | Show detailed output with metrics |
 | `--dry-run` | Show what would run without executing |
 
@@ -295,15 +296,22 @@ pip install -e ".[all]"
 
 ## Known Issues
 
-See `gh issue list` for current open issues. Key themes:
-- Provider consistency: env var fallback only works for vertex-ai (#27)
+No open issues are currently tracked. Check `gh issue list` (or the GitHub repo)
+for the latest. Standing maintenance debt to be aware of:
+- **mypy not clean**: ~78 structural errors remain (typer `untyped-decorator`
+  pattern in `cli/main.py`, missing third-party stubs e.g. `types-PyYAML`).
+  Not regressions, but `mypy --strict` is not yet green.
 
-### Resolved in v0.6.2
-- ~~Config wiring: `providers[].default_model` not passed to provider constructors (#26, #28)~~ — Fixed in v0.6.0
-- ~~Model defaults: hardcoded Gemini model name outdated (#30)~~ — Fixed in v0.6.0
-- ~~File injection: `--files` via wrapper not reaching models (#31)~~ — Native `--files` flag added in v0.6.2
-- ~~Config defaults: no `output_format` config option (#29)~~ — Fixed in v0.6.0
-- ~~`council version` shows stale version (#35)~~ — Fixed in v0.6.2
+### Resolved (historical, v0.6.x)
+- ~~Config wiring: `providers[].default_model` not passed to provider constructors~~ — Fixed in v0.6.0
+- ~~Model defaults: hardcoded Gemini model name outdated~~ — Fixed in v0.6.0
+- ~~File injection: `--files` via wrapper not reaching models~~ — Native `--files` flag added in v0.6.2
+- ~~Config defaults: no `output_format` config option~~ — Fixed in v0.6.0
+- ~~`council version` shows stale version~~ — Fixed in v0.6.2
+
+### Recent additions (v0.7.x)
+- Human-readable Markdown output via `council run --format markdown` (and the
+  `output_format` config key); honored for both stdout and `--output` writes.
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "the-llm-council"
-version = "0.7.16"
+version = "0.7.17"
 description = "Multi-LLM Council Framework for adversarial debate, cross-validation, and structured decision-making"
 readme = "README.md"
 license = "MIT"

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -3,7 +3,7 @@ name: council
 description: Run multi-LLM council for adversarial debate and cross-validation. Use it for implementation, architecture, review, security, research, and planning tasks with the canonical llm-council subagents and modes.
 ---
 
-# LLM Council Skill (v0.7.16)
+# LLM Council Skill (v0.7.17)
 
 Multi-model council: parallel drafts, adversarial critique, validated synthesis.
 
@@ -16,14 +16,14 @@ Multi-model council: parallel drafts, adversarial critique, validated synthesis.
 Install the package:
 
 ```bash
-pip install 'the-llm-council>=0.7.16'
+pip install 'the-llm-council>=0.7.17'
 ```
 
 Optional extras:
 
 ```bash
-pip install 'the-llm-council[anthropic,openai,gemini]>=0.7.16'
-pip install 'the-llm-council[vertex]>=0.7.16'
+pip install 'the-llm-council[anthropic,openai,gemini]>=0.7.17'
+pip install 'the-llm-council[vertex]>=0.7.17'
 ```
 
 Configure at least one provider key:

--- a/src/llm_council/cli/main.py
+++ b/src/llm_council/cli/main.py
@@ -296,6 +296,93 @@ def _set_nested_value(data: dict[str, Any], key: str, value: Any) -> None:
     current[parts[-1]] = final_value
 
 
+def _render_result_markdown(
+    result: Any,
+    *,
+    resolved_mode: str | None = None,
+    provider_list: list[str] | None = None,
+    include_metrics: bool = True,
+) -> str:
+    """Render a CouncilResult as clean, human-readable Markdown.
+
+    Covers the council output (or validation errors), the adversarial critique,
+    and a metrics summary. Used both for stdout rendering and ``--output`` writes
+    when ``--format markdown`` is requested.
+    """
+    lines: list[str] = []
+    success = bool(getattr(result, "success", False))
+    status = "SUCCESS" if success else "FAILED"
+    lines.append(f"# Council Result: {status}")
+    lines.append("")
+
+    if success:
+        output = getattr(result, "output", None)
+        lines.append("## Output")
+        lines.append("")
+        if output:
+            lines.append("```json")
+            lines.append(json.dumps(output, indent=2, default=str))
+            lines.append("```")
+        else:
+            lines.append("_No output produced._")
+        lines.append("")
+    else:
+        lines.append("## Errors")
+        lines.append("")
+        errors = getattr(result, "validation_errors", None) or []
+        top_error = getattr(result, "error", None)
+        if top_error:
+            errors = [top_error, *errors]
+        if errors:
+            for err in errors:
+                lines.append(f"- {err}")
+        else:
+            lines.append("- Unknown error")
+        lines.append("")
+
+    critique = getattr(result, "critique", None)
+    if critique:
+        lines.append("## Critique")
+        lines.append("")
+        lines.append(str(critique).strip())
+        lines.append("")
+
+    if include_metrics:
+        lines.append("## Metrics")
+        lines.append("")
+        lines.append(f"- Duration: {getattr(result, 'duration_ms', 0)}ms")
+        lines.append(f"- Synthesis attempts: {getattr(result, 'synthesis_attempts', 1)}")
+        cost_estimate = getattr(result, "cost_estimate", None)
+        if cost_estimate is not None:
+            cost = getattr(cost_estimate, "estimated_cost_usd", None)
+            if cost is not None:
+                lines.append(f"- Estimated cost: ${cost:.4f}")
+        run_id = getattr(result, "run_id", None)
+        if run_id:
+            lines.append(f"- Run ID: {run_id}")
+
+        execution_plan = getattr(result, "execution_plan", None) or {}
+        plan_mode = execution_plan.get("mode") or resolved_mode
+        if plan_mode:
+            lines.append(f"- Mode: {plan_mode}")
+        plan_providers = execution_plan.get("providers") or provider_list
+        if plan_providers:
+            lines.append(f"- Providers: {', '.join(plan_providers)}")
+        lines.append("")
+
+    routing_decision = getattr(result, "routing_decision", None)
+    if getattr(result, "routed", False) and routing_decision:
+        lines.append("## Routing")
+        lines.append("")
+        routing_mode = routing_decision.get("mode")
+        mode_suffix = f" --mode {routing_mode}" if isinstance(routing_mode, str) else ""
+        lines.append(f"- Routed to: {routing_decision.get('subagent_to_run')}{mode_suffix}")
+        lines.append(f"- Router reasoning: {routing_decision.get('reasoning') or 'n/a'}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 @app.command()
 def run(
     subagent: Annotated[str, typer.Argument(help="Subagent type (drafter, critic, planner, etc.)")],
@@ -320,6 +407,14 @@ def run(
         bool,
         typer.Option("--json", help="Output as JSON"),
     ] = False,
+    output_format: Annotated[
+        str | None,
+        typer.Option(
+            "--format",
+            help="Output format: 'json' or 'markdown' (alias 'md'). "
+            "Default preserves the rich/JSON behavior.",
+        ),
+    ] = None,
     verbose: Annotated[
         bool,
         typer.Option("--verbose", "-v", help="Show detailed output"),
@@ -484,9 +579,35 @@ def run(
     # Load defaults from config file
     config_defaults = _load_config_defaults()
 
-    # Apply output_format default from config (CLI flag takes precedence)
-    if not output_json:
-        output_json = config_defaults.get("output_format") == "json"
+    # Resolve the effective output format. Precedence:
+    #   1. --format CLI flag (json | markdown/md)
+    #   2. --json flag (back-compat shorthand for --format json)
+    #   3. config output_format (json | markdown/md | rich)
+    # Default preserves the existing rich/JSON behavior.
+    _format_aliases = {"json": "json", "markdown": "markdown", "md": "markdown"}
+    markdown_output = False
+    if output_format is not None:
+        normalized_format = _format_aliases.get(output_format.strip().lower())
+        if normalized_format is None:
+            console.print(
+                f"[red]Error:[/red] Invalid --format '{output_format}'. "
+                "Valid values: json, markdown (alias: md)."
+            )
+            raise typer.Exit(1)
+        if normalized_format == "json":
+            output_json = True
+        else:
+            markdown_output = True
+            output_json = False
+    elif output_json:
+        # Explicit --json flag already enables JSON output.
+        pass
+    else:
+        config_format = (config_defaults.get("output_format") or "").strip().lower()
+        if config_format == "json":
+            output_json = True
+        elif _format_aliases.get(config_format) == "markdown":
+            markdown_output = True
 
     # Resolve agent aliases
     resolved_agent, resolved_mode, was_deprecated = _resolve_agent_alias(subagent, mode)
@@ -593,13 +714,22 @@ def run(
             council.run(task=task_text, subagent=resolved_agent, follow_router=route)
         )
 
-        output_payload = json.dumps(result.model_dump(), indent=2, default=str)
+        if markdown_output:
+            output_payload = _render_result_markdown(
+                result,
+                resolved_mode=resolved_mode,
+                provider_list=provider_list,
+            )
+        else:
+            output_payload = json.dumps(result.model_dump(), indent=2, default=str)
 
         # Write to file or stdout
         if output_file:
             output_file.parent.mkdir(parents=True, exist_ok=True)
             output_file.write_text(output_payload)
             _print(f"[green]Output written to {output_file}[/green]")
+        elif markdown_output:
+            print(output_payload, end="" if output_payload.endswith("\n") else "\n")
         elif output_json:
             print(output_payload)
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -702,6 +702,208 @@ class TestOutputFormatConfig:
                 assert "{" in result.stdout or "providers" in result.stdout
 
 
+class TestMarkdownOutputFormat:
+    """Tests for --format markdown human-readable output."""
+
+    def _success_result(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            success=True,
+            output={"result": "ship it"},
+            critique="The draft is solid but verbose.",
+            duration_ms=4321,
+            synthesis_attempts=2,
+            cost_estimate=SimpleNamespace(estimated_cost_usd=0.0456),
+            run_id="run-123",
+            execution_plan={"mode": "impl", "providers": ["openrouter"]},
+            routed=False,
+            routing_decision=None,
+            validation_errors=None,
+        )
+
+    def test_render_markdown_success(self):
+        """Formatter emits Markdown headings, output, critique, and metrics."""
+        from llm_council.cli.main import _render_result_markdown
+
+        md = _render_result_markdown(
+            self._success_result(),
+            resolved_mode="impl",
+            provider_list=["openrouter"],
+        )
+        assert md.startswith("# Council Result: SUCCESS")
+        assert "## Output" in md
+        assert '"result": "ship it"' in md
+        assert "## Critique" in md
+        assert "The draft is solid but verbose." in md
+        assert "## Metrics" in md
+        assert "- Duration: 4321ms" in md
+        assert "- Synthesis attempts: 2" in md
+        assert "- Estimated cost: $0.0456" in md
+        assert "- Run ID: run-123" in md
+        assert "- Mode: impl" in md
+        assert "- Providers: openrouter" in md
+        assert md.endswith("\n")
+
+    def test_render_markdown_failure_lists_errors(self):
+        """Failed results render an Errors section with validation messages."""
+        from types import SimpleNamespace
+
+        from llm_council.cli.main import _render_result_markdown
+
+        result = SimpleNamespace(
+            success=False,
+            output=None,
+            critique=None,
+            duration_ms=12,
+            synthesis_attempts=1,
+            cost_estimate=None,
+            run_id=None,
+            execution_plan={},
+            routed=False,
+            routing_decision=None,
+            validation_errors=["missing key 'foo'", "bad type"],
+        )
+        md = _render_result_markdown(result, include_metrics=False)
+        assert md.startswith("# Council Result: FAILED")
+        assert "## Errors" in md
+        assert "- missing key 'foo'" in md
+        assert "- bad type" in md
+        assert "## Metrics" not in md
+
+    def test_run_format_markdown_stdout(self):
+        """--format markdown renders Markdown to stdout (no rich panel, no raw JSON dump)."""
+        mock_result = self._success_result()
+        # model_dump should NOT be used for markdown output
+        mock_result.model_dump = MagicMock(side_effect=AssertionError("model_dump used"))
+
+        with (
+            patch("llm_council.Council") as mock_council_class,
+            patch("asyncio.run") as mock_run,
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={},
+            ),
+        ):
+            mock_council_class.return_value = MagicMock()
+            mock_run.return_value = mock_result
+
+            result = runner.invoke(
+                app, ["run", "router", "Test task", "--format", "markdown"]
+            )
+            assert result.exit_code == 0
+            assert "# Council Result: SUCCESS" in result.stdout
+            assert "## Metrics" in result.stdout
+
+    def test_run_format_md_alias(self):
+        """--format md is accepted as an alias for markdown."""
+        mock_result = self._success_result()
+
+        with (
+            patch("llm_council.Council") as mock_council_class,
+            patch("asyncio.run") as mock_run,
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={},
+            ),
+        ):
+            mock_council_class.return_value = MagicMock()
+            mock_run.return_value = mock_result
+
+            result = runner.invoke(app, ["run", "router", "Test task", "--format", "md"])
+            assert result.exit_code == 0
+            assert "# Council Result: SUCCESS" in result.stdout
+
+    def test_run_format_json_matches_json_flag(self):
+        """--format json behaves like --json (raw JSON, no rich panel)."""
+        mock_result = self._success_result()
+        mock_result.model_dump = MagicMock(
+            return_value={"success": True, "output": {"result": "ship it"}}
+        )
+
+        with (
+            patch("llm_council.Council") as mock_council_class,
+            patch("asyncio.run") as mock_run,
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={},
+            ),
+        ):
+            mock_council_class.return_value = MagicMock()
+            mock_run.return_value = mock_result
+
+            result = runner.invoke(
+                app, ["run", "router", "Test task", "--format", "json"]
+            )
+            assert result.exit_code == 0
+            assert "Council Result" not in result.stdout
+            assert '"success": true' in result.stdout
+
+    def test_run_format_invalid_value_errors(self):
+        """An unknown --format value exits with an error before running the council."""
+        with (
+            patch("llm_council.Council") as mock_council_class,
+            patch("asyncio.run") as mock_run,
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={},
+            ),
+        ):
+            mock_council_class.return_value = MagicMock()
+            mock_run.return_value = self._success_result()
+
+            result = runner.invoke(
+                app, ["run", "router", "Test task", "--format", "yaml"]
+            )
+            assert result.exit_code == 1
+            assert "Invalid --format" in result.stdout
+
+    def test_run_format_markdown_writes_file(self, tmp_path):
+        """--format markdown with --output writes Markdown (not JSON) to the file."""
+        out_file = tmp_path / "result.md"
+        mock_result = self._success_result()
+
+        with (
+            patch("llm_council.Council") as mock_council_class,
+            patch("asyncio.run") as mock_run,
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={},
+            ),
+        ):
+            mock_council_class.return_value = MagicMock()
+            mock_run.return_value = mock_result
+
+            result = runner.invoke(
+                app,
+                ["run", "router", "Test task", "--format", "markdown", "-o", str(out_file)],
+            )
+            assert result.exit_code == 0
+            assert out_file.exists()
+            content = out_file.read_text()
+            assert content.startswith("# Council Result: SUCCESS")
+            assert "## Metrics" in content
+
+    def test_run_config_output_format_markdown(self):
+        """config output_format: markdown renders Markdown when no CLI flag is given."""
+        mock_result = self._success_result()
+
+        with (
+            patch("llm_council.Council") as mock_council_class,
+            patch("asyncio.run") as mock_run,
+            patch(
+                "llm_council.cli.main._load_config_defaults",
+                return_value={"output_format": "markdown"},
+            ),
+        ):
+            mock_council_class.return_value = MagicMock()
+            mock_run.return_value = mock_result
+
+            result = runner.invoke(app, ["run", "router", "Test task"])
+            assert result.exit_code == 0
+            assert "# Council Result: SUCCESS" in result.stdout
+
+
 class TestCLIContextMetadata:
     """Tests for file-ingestion metadata passed into council runs."""
 


### PR DESCRIPTION
## Summary

Adds human-readable Markdown output to `council run` and ships it as **v0.7.17**.

- **New `--format` option** (`json` | `markdown`/`md`) on `council run`. Renders the council result as clean Markdown — status heading, Output/Errors, Critique, Metrics, and Routing sections — honored for both stdout and `--output` file writes.
- **Precedence:** `--format` > `--json` > config `output_format`. Default behavior (rich panel) is unchanged; `--json` now maps to `--format json`.
- **Docs refresh:** CLAUDE.md updated to v0.7.17 (documents `--format`, corrects version header, drops stale issue refs).
- **Release bookkeeping:** version bumped to 0.7.17 across pyproject.toml, plugin.json, SKILL.md, CLAUDE.md; CHANGELOG entry added.

## Implementation

- `src/llm_council/cli/main.py` — `_render_result_markdown(...)` helper (duck-typed over the council result) + `--format` wiring.
- `tests/test_cli.py` — `TestMarkdownOutputFormat` (8 tests): formatter success/failure, `--format markdown`/`md` stdout, `--format json` parity with `--json`, invalid-format exit, `--output` write, config-driven `output_format: markdown`.

## Verification

- Full suite: **379 passed**
- `ruff check src/`: clean
- No new mypy errors
- Live-rendered success and failure cases manually verified

No orchestrator/protocol changes — self-contained.

https://claude.ai/code/session_01ATpDm2DPT8oS35UU43xWYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATpDm2DPT8oS35UU43xWYq)_