### PR TITLE
fix: green the CI pipeline (ruff format + 9 mypy strict errors)

### DIFF
--- a/src/llm_council/__init__.py
+++ b/src/llm_council/__init__.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 try:
-    import tomllib
+    import tomllib  # type: ignore[import-not-found]
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
     tomllib = None
 

--- a/src/llm_council/engine/capabilities.py
+++ b/src/llm_council/engine/capabilities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, cast
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -197,7 +197,7 @@ def _apply_capability_overrides(
     """
 
     normalized_execution_profile = (
-        cast(ExecutionProfile, requested_execution_profile)
+        requested_execution_profile
         if requested_execution_profile in _EXECUTION_PROFILE_ORDER
         else None
     )
@@ -209,9 +209,7 @@ def _apply_capability_overrides(
             plan.execution_profile = normalized_execution_profile
 
     normalized_budget_class = (
-        cast(BudgetClass, requested_budget_class)
-        if requested_budget_class in _BUDGET_CLASS_ORDER
-        else None
+        requested_budget_class if requested_budget_class in _BUDGET_CLASS_ORDER else None
     )
     if normalized_budget_class is not None:
         if _BUDGET_CLASS_ORDER[normalized_budget_class] > _BUDGET_CLASS_ORDER[plan.budget_class]:

--- a/src/llm_council/engine/orchestrator.py
+++ b/src/llm_council/engine/orchestrator.py
@@ -21,7 +21,15 @@ import logging
 import math
 import re
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -831,7 +839,7 @@ class Orchestrator:
                 phase="critique",
                 system_prompt=system_prompt,
                 prompt_builder=lambda profile: self._format_critique_prompt(
-                    self._task,
+                    self._task or "",
                     drafts,
                     context_override=self._phase_context_override,
                     draft_limit=profile.get("draft_limit"),
@@ -929,29 +937,37 @@ class Orchestrator:
                 use_raw_drafts = bool(errors) and any(
                     handoff.get("findings") for handoff in self._draft_handoffs.values()
                 )
+
+                def _build_synthesis_prompt(
+                    profile: Mapping[str, int | None],
+                    *,
+                    _errors: tuple[str, ...] = tuple(errors),
+                    _use_raw_drafts: bool = use_raw_drafts,
+                    _inline_schema: bool = not supports_structured_output,
+                ) -> str:
+                    return self._format_synthesis_prompt(
+                        task=self._task or "",
+                        drafts=drafts,
+                        critique=critique,
+                        schema=schema,
+                        errors=_errors,
+                        context_override=self._phase_context_override,
+                        use_raw_drafts=_use_raw_drafts,
+                        draft_limit=profile.get("draft_limit"),
+                        excerpt_limit=int(profile.get("excerpt_limit") or 320),
+                        max_sources=profile.get("max_sources"),
+                        max_findings=profile.get("max_findings"),
+                        critique_limit=profile.get("critique_limit"),
+                        omit_drafts=bool(profile.get("omit_drafts")),
+                        inline_schema=_inline_schema,
+                        omit_context=bool(profile.get("omit_context")),
+                    )
+
                 user_prompt, _prompt_meta = self._select_prompt_profile(
                     provider_name=provider_name,
                     phase="synthesis",
                     system_prompt=system_prompt,
-                    prompt_builder=lambda profile, *, _errors=tuple(errors), _use_raw_drafts=use_raw_drafts, _inline_schema=not supports_structured_output: (
-                        self._format_synthesis_prompt(
-                            task=self._task,
-                            drafts=drafts,
-                            critique=critique,
-                            schema=schema,
-                            errors=_errors,
-                            context_override=self._phase_context_override,
-                            use_raw_drafts=_use_raw_drafts,
-                            draft_limit=profile.get("draft_limit"),
-                            excerpt_limit=int(profile.get("excerpt_limit") or 320),
-                            max_sources=profile.get("max_sources"),
-                            max_findings=profile.get("max_findings"),
-                            critique_limit=profile.get("critique_limit"),
-                            omit_drafts=bool(profile.get("omit_drafts")),
-                            inline_schema=_inline_schema,
-                            omit_context=bool(profile.get("omit_context")),
-                        )
-                    ),
+                    prompt_builder=_build_synthesis_prompt,
                 )
 
                 request = GenerateRequest(
@@ -973,7 +989,7 @@ class Orchestrator:
 
                 if supports_structured_output:
                     request.structured_output = StructuredOutputConfig(
-                        json_schema=schema,
+                        json_schema=schema or {},
                         name=self._subagent_name or "council_output",
                         strict=True,
                     )
@@ -3117,7 +3133,7 @@ class Orchestrator:
         }
 
     @contextmanager
-    def _temporary_context_override(self, context_override: str | None):
+    def _temporary_context_override(self, context_override: str | None) -> Iterator[None]:
         """Temporarily swap the configured system context for prompt rendering."""
 
         original_prepared = self._prepared_reference_context

--- a/src/llm_council/engine/orchestrator.py
+++ b/src/llm_council/engine/orchestrator.py
@@ -81,21 +81,103 @@ _LARGE_SINGLE_RUN_WARNING_TOKENS = 12_000
 _DEFAULT_ESTIMATE_METHOD = "chars_div_4_padded"
 _PHASE_PROMPT_PROFILES: dict[str, list[dict[str, int | None]]] = {
     "critique": [
-        {"draft_limit": 1_800, "excerpt_limit": 320, "max_sources": 2, "max_findings": 5, "critique_limit": None},
-        {"draft_limit": 1_200, "excerpt_limit": 220, "max_sources": 2, "max_findings": 4, "critique_limit": None},
-        {"draft_limit": 800, "excerpt_limit": 160, "max_sources": 1, "max_findings": 3, "critique_limit": None},
-        {"draft_limit": 500, "excerpt_limit": 120, "max_sources": 1, "max_findings": 2, "critique_limit": None},
-        {"draft_limit": 300, "excerpt_limit": 80, "max_sources": 0, "max_findings": 2, "critique_limit": None},
+        {
+            "draft_limit": 1_800,
+            "excerpt_limit": 320,
+            "max_sources": 2,
+            "max_findings": 5,
+            "critique_limit": None,
+        },
+        {
+            "draft_limit": 1_200,
+            "excerpt_limit": 220,
+            "max_sources": 2,
+            "max_findings": 4,
+            "critique_limit": None,
+        },
+        {
+            "draft_limit": 800,
+            "excerpt_limit": 160,
+            "max_sources": 1,
+            "max_findings": 3,
+            "critique_limit": None,
+        },
+        {
+            "draft_limit": 500,
+            "excerpt_limit": 120,
+            "max_sources": 1,
+            "max_findings": 2,
+            "critique_limit": None,
+        },
+        {
+            "draft_limit": 300,
+            "excerpt_limit": 80,
+            "max_sources": 0,
+            "max_findings": 2,
+            "critique_limit": None,
+        },
     ],
     "synthesis": [
-        {"draft_limit": 1_200, "excerpt_limit": 220, "max_sources": 2, "max_findings": 3, "critique_limit": 12_000},
-        {"draft_limit": 900, "excerpt_limit": 160, "max_sources": 1, "max_findings": 3, "critique_limit": 8_000},
-        {"draft_limit": 650, "excerpt_limit": 120, "max_sources": 1, "max_findings": 2, "critique_limit": 5_000},
-        {"draft_limit": 450, "excerpt_limit": 80, "max_sources": 1, "max_findings": 2, "critique_limit": 3_000},
-        {"draft_limit": 300, "excerpt_limit": 0, "max_sources": 0, "max_findings": 1, "critique_limit": 1_800},
-        {"draft_limit": 220, "excerpt_limit": 0, "max_sources": 0, "max_findings": 1, "critique_limit": 1_200},
-        {"draft_limit": 0, "excerpt_limit": 0, "max_sources": 0, "max_findings": 0, "critique_limit": 1_800, "omit_drafts": 1, "omit_context": 1},
-        {"draft_limit": 0, "excerpt_limit": 0, "max_sources": 0, "max_findings": 0, "critique_limit": 1_000, "omit_drafts": 1, "omit_context": 1},
+        {
+            "draft_limit": 1_200,
+            "excerpt_limit": 220,
+            "max_sources": 2,
+            "max_findings": 3,
+            "critique_limit": 12_000,
+        },
+        {
+            "draft_limit": 900,
+            "excerpt_limit": 160,
+            "max_sources": 1,
+            "max_findings": 3,
+            "critique_limit": 8_000,
+        },
+        {
+            "draft_limit": 650,
+            "excerpt_limit": 120,
+            "max_sources": 1,
+            "max_findings": 2,
+            "critique_limit": 5_000,
+        },
+        {
+            "draft_limit": 450,
+            "excerpt_limit": 80,
+            "max_sources": 1,
+            "max_findings": 2,
+            "critique_limit": 3_000,
+        },
+        {
+            "draft_limit": 300,
+            "excerpt_limit": 0,
+            "max_sources": 0,
+            "max_findings": 1,
+            "critique_limit": 1_800,
+        },
+        {
+            "draft_limit": 220,
+            "excerpt_limit": 0,
+            "max_sources": 0,
+            "max_findings": 1,
+            "critique_limit": 1_200,
+        },
+        {
+            "draft_limit": 0,
+            "excerpt_limit": 0,
+            "max_sources": 0,
+            "max_findings": 0,
+            "critique_limit": 1_800,
+            "omit_drafts": 1,
+            "omit_context": 1,
+        },
+        {
+            "draft_limit": 0,
+            "excerpt_limit": 0,
+            "max_sources": 0,
+            "max_findings": 0,
+            "critique_limit": 1_000,
+            "omit_drafts": 1,
+            "omit_context": 1,
+        },
     ],
 }
 _STOPWORDS = frozenset(
@@ -839,9 +921,11 @@ class Orchestrator:
                     "You are the synthesizer. Combine drafts and critique into a single response. "
                     "Return ONLY valid JSON that matches the provided schema."
                 )
-                supports_structured_output = bool(schema) and await adapter.supports(
-                    "structured_output"
-                ) and not force_inline_schema
+                supports_structured_output = (
+                    bool(schema)
+                    and await adapter.supports("structured_output")
+                    and not force_inline_schema
+                )
                 use_raw_drafts = bool(errors) and any(
                     handoff.get("findings") for handoff in self._draft_handoffs.values()
                 )
@@ -849,25 +933,24 @@ class Orchestrator:
                     provider_name=provider_name,
                     phase="synthesis",
                     system_prompt=system_prompt,
-                    prompt_builder=lambda profile, *,
-                    _errors=tuple(errors),
-                    _use_raw_drafts=use_raw_drafts,
-                    _inline_schema=not supports_structured_output: self._format_synthesis_prompt(
-                        task=self._task,
-                        drafts=drafts,
-                        critique=critique,
-                        schema=schema,
-                        errors=_errors,
-                        context_override=self._phase_context_override,
-                        use_raw_drafts=_use_raw_drafts,
-                        draft_limit=profile.get("draft_limit"),
-                        excerpt_limit=int(profile.get("excerpt_limit") or 320),
-                        max_sources=profile.get("max_sources"),
-                        max_findings=profile.get("max_findings"),
-                        critique_limit=profile.get("critique_limit"),
-                        omit_drafts=bool(profile.get("omit_drafts")),
-                        inline_schema=_inline_schema,
-                        omit_context=bool(profile.get("omit_context")),
+                    prompt_builder=lambda profile, *, _errors=tuple(errors), _use_raw_drafts=use_raw_drafts, _inline_schema=not supports_structured_output: (
+                        self._format_synthesis_prompt(
+                            task=self._task,
+                            drafts=drafts,
+                            critique=critique,
+                            schema=schema,
+                            errors=_errors,
+                            context_override=self._phase_context_override,
+                            use_raw_drafts=_use_raw_drafts,
+                            draft_limit=profile.get("draft_limit"),
+                            excerpt_limit=int(profile.get("excerpt_limit") or 320),
+                            max_sources=profile.get("max_sources"),
+                            max_findings=profile.get("max_findings"),
+                            critique_limit=profile.get("critique_limit"),
+                            omit_drafts=bool(profile.get("omit_drafts")),
+                            inline_schema=_inline_schema,
+                            omit_context=bool(profile.get("omit_context")),
+                        )
                     ),
                 )
 
@@ -1660,7 +1743,9 @@ class Orchestrator:
             system_prompt = self._system_prompt
             user_prompt = self._format_draft_prompt(self._task)
             decisions = {
-                provider_name: self._draft_budget_decision(provider_name, system_prompt, user_prompt)
+                provider_name: self._draft_budget_decision(
+                    provider_name, system_prompt, user_prompt
+                )
                 for provider_name in self._provider_names
             }
         return max(
@@ -1807,7 +1892,9 @@ class Orchestrator:
         phase_timeout = self._provider_request_timeout_seconds(phase, provider_name=provider_name)
         queue_headroom = float(budget["queue_wait_headroom_seconds"][phase])
         safe_envelope = int(budget["safe_input_tokens"][phase])
-        timeout_factor = max(min((phase_timeout - queue_headroom) / max(phase_timeout, 1.0), 1.0), 0.55)
+        timeout_factor = max(
+            min((phase_timeout - queue_headroom) / max(phase_timeout, 1.0), 1.0), 0.55
+        )
         effective_envelope = max(int(safe_envelope * timeout_factor), 1)
         estimated_tokens, estimate_method, _padding = self._estimate_tokens_for_provider(
             provider_name, system_prompt, user_prompt
@@ -1839,7 +1926,9 @@ class Orchestrator:
 
         if self._execution_plan is None:
             return
-        entries = self._execution_plan.setdefault("phase_prompt_compaction", {}).setdefault(phase, [])
+        entries = self._execution_plan.setdefault("phase_prompt_compaction", {}).setdefault(
+            phase, []
+        )
         entries.append(dict(decision))
 
     def _prompt_profile_candidates(self, phase: str) -> list[dict[str, int | None]]:
@@ -1898,7 +1987,9 @@ class Orchestrator:
             return self._prepared_reference_context
         return self._config.system_context or ""
 
-    def _extract_file_context_blocks_from_text(self, context: str) -> tuple[str, list[tuple[str, str]]]:
+    def _extract_file_context_blocks_from_text(
+        self, context: str
+    ) -> tuple[str, list[tuple[str, str]]]:
         """Parse CLI-injected file blocks from arbitrary reference context."""
 
         if not context:
@@ -2021,7 +2112,9 @@ class Orchestrator:
         anchor = re.sub(r"[^a-z0-9]+", "-", heading.lower()).strip("-")
         return anchor or None
 
-    def _slice_markdown_block(self, path: str, content: str) -> tuple[str, list[dict[str, Any]], bool]:
+    def _slice_markdown_block(
+        self, path: str, content: str
+    ) -> tuple[str, list[dict[str, Any]], bool]:
         """Prepare a markdown block by keeping the most relevant sections."""
 
         keywords = self._task_keywords()
@@ -2176,7 +2269,9 @@ class Orchestrator:
             provider_name, system_prompt, user_prompt
         )
         safe_envelope = int(budget["safe_input_tokens"]["draft"])
-        timeout_factor = max(min((phase_timeout - queue_headroom) / max(phase_timeout, 1.0), 1.0), 0.55)
+        timeout_factor = max(
+            min((phase_timeout - queue_headroom) / max(phase_timeout, 1.0), 1.0), 0.55
+        )
         effective_envelope = max(int(safe_envelope * timeout_factor), 1)
 
         forced_reason = "none"
@@ -2216,7 +2311,10 @@ class Orchestrator:
                 f"Large bounded draft for {provider_name} remained single-run "
                 f"({estimated_tokens} estimated tokens; {len(blocks)} file block(s))."
             )
-        if budget["budget_source"] == "default" and self._provider_identity(provider_name) != "default":
+        if (
+            budget["budget_source"] == "default"
+            and self._provider_identity(provider_name) != "default"
+        ):
             warnings.append(
                 f"Using default draft budget fallback for provider identity "
                 f"'{self._provider_identity(provider_name)}'."
@@ -2246,9 +2344,7 @@ class Orchestrator:
             "evidence_pack_chars": len(self._prepared_reference_context or ""),
         }
 
-    def _evidence_sources_for_chunk(
-        self, chunk: Sequence[tuple[str, str]]
-    ) -> list[dict[str, Any]]:
+    def _evidence_sources_for_chunk(self, chunk: Sequence[tuple[str, str]]) -> list[dict[str, Any]]:
         """Build anchored evidence metadata for a prepared context chunk."""
 
         sources: list[dict[str, Any]] = []
@@ -2556,9 +2652,7 @@ class Orchestrator:
             summary_basis = "; ".join(issue["description"] for issue in issues[:2])
         else:
             verdict = "approve_with_comments"
-            summary_basis = (
-                "Draft findings were incomplete, so this result is based on bounded evidence fallback."
-            )
+            summary_basis = "Draft findings were incomplete, so this result is based on bounded evidence fallback."
 
         review_summary = self._compact_text(
             f"Fallback reviewer synthesis based on bounded chunk evidence: {summary_basis}",
@@ -2578,7 +2672,9 @@ class Orchestrator:
             "review_type": "code_quality",
             "confidence": 58 if issues else 42,
             "blocking_issues": [
-                issue["description"] for issue in issues if issue["severity"] in {"critical", "high"}
+                issue["description"]
+                for issue in issues
+                if issue["severity"] in {"critical", "high"}
             ][:5],
         }
 
@@ -2666,7 +2762,11 @@ class Orchestrator:
             if len(stripped) < 20:
                 continue
             lower = stripped.lower()
-            if lower.startswith("chunk ") or lower.startswith("provider:") or lower.startswith("source anchors:"):
+            if (
+                lower.startswith("chunk ")
+                or lower.startswith("provider:")
+                or lower.startswith("source anchors:")
+            ):
                 continue
             if stripped not in candidates:
                 candidates.append(stripped)
@@ -2690,7 +2790,10 @@ class Orchestrator:
         """Infer a reviewer issue category from issue text."""
 
         lowered = description.lower()
-        if any(token in lowered for token in ("security", "auth", "exposure", "injection", "vulnerability")):
+        if any(
+            token in lowered
+            for token in ("security", "auth", "exposure", "injection", "vulnerability")
+        ):
             return "security"
         if any(token in lowered for token in ("performance", "latency", "slow", "timeout")):
             return "performance"
@@ -2698,7 +2801,10 @@ class Orchestrator:
             return "testing"
         if any(token in lowered for token in ("doc", "documentation", "readme")):
             return "documentation"
-        if any(token in lowered for token in ("logic", "contradict", "ambigu", "overclaim", "comparable")):
+        if any(
+            token in lowered
+            for token in ("logic", "contradict", "ambigu", "overclaim", "comparable")
+        ):
             return "logic"
         if any(token in lowered for token in ("maintain", "refactor", "complex")):
             return "maintainability"
@@ -2731,11 +2837,7 @@ class Orchestrator:
             if not recommendation or recommendation in seen:
                 continue
             seen.add(recommendation)
-            priority = (
-                "must_fix"
-                if issue.get("severity") in {"critical", "high"}
-                else "should_fix"
-            )
+            priority = "must_fix" if issue.get("severity") in {"critical", "high"} else "should_fix"
             recommendations.append(
                 {
                     "priority": priority,
@@ -2927,9 +3029,7 @@ class Orchestrator:
         if self._execution_plan is not None:
             budgets = self._execution_plan.setdefault("draft_budget_decisions", {})
             budgets[provider_name] = {
-                key: value
-                for key, value in decision.items()
-                if key not in {"chunks"}
+                key: value for key, value in decision.items() if key not in {"chunks"}
             }
             if decision["warnings"]:
                 self._execution_plan.setdefault("warnings", []).extend(decision["warnings"])
@@ -3009,7 +3109,11 @@ class Orchestrator:
                 "has_file_blocks": has_file_blocks,
             },
             "provider_decisions": provider_decisions,
-            "warnings": [warning for decision in provider_decisions.values() for warning in decision["warnings"]],
+            "warnings": [
+                warning
+                for decision in provider_decisions.values()
+                for warning in decision["warnings"]
+            ],
         }
 
     @contextmanager

--- a/src/llm_council/providers/anthropic.py
+++ b/src/llm_council/providers/anthropic.py
@@ -11,7 +11,7 @@ import logging
 import os
 import time
 from collections.abc import AsyncIterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from llm_council.providers.base import (
     DoctorResult,
@@ -115,7 +115,7 @@ def _prepare_schema_for_anthropic(schema: dict[str, Any]) -> dict[str, Any]:
 
         return node
 
-    return _normalize(schema)
+    return cast("dict[str, Any]", _normalize(schema))
 
 
 logger = logging.getLogger(__name__)

--- a/src/llm_council/providers/cli/codex.py
+++ b/src/llm_council/providers/cli/codex.py
@@ -233,9 +233,7 @@ def _ingest_codex_stdout_line(line: str, state: _LiveCodexState) -> None:
             state.error_message = message
 
 
-async def _read_codex_stdout(
-    stream: asyncio.StreamReader | None, state: _LiveCodexState
-) -> None:
+async def _read_codex_stdout(stream: asyncio.StreamReader | None, state: _LiveCodexState) -> None:
     """Consume Codex stdout incrementally."""
 
     if stream is None:
@@ -252,9 +250,7 @@ async def _read_codex_stdout(
             state.turn_started_at = now
 
 
-async def _read_codex_stderr(
-    stream: asyncio.StreamReader | None, state: _LiveCodexState
-) -> None:
+async def _read_codex_stderr(stream: asyncio.StreamReader | None, state: _LiveCodexState) -> None:
     """Consume Codex stderr incrementally."""
 
     if stream is None:
@@ -503,9 +499,7 @@ class CodexCLIProvider(ProviderAdapter):
                 )
                 with os.fdopen(schema_fd, "w", encoding="utf-8") as schema_file:
                     json.dump(
-                        _prepare_schema_for_codex(
-                            dict(request.structured_output.json_schema)
-                        ),
+                        _prepare_schema_for_codex(dict(request.structured_output.json_schema)),
                         schema_file,
                     )
             cmd = self._build_command(

--- a/src/llm_council/providers/cli/gemini_cli.py
+++ b/src/llm_council/providers/cli/gemini_cli.py
@@ -114,9 +114,7 @@ def _normalize_usage(raw_stats: Any) -> dict[str, int] | None:
 
     if not isinstance(raw_stats, dict):
         return None
-    prompt_tokens = int(
-        raw_stats.get("inputTokenCount", raw_stats.get("input_tokens", 0)) or 0
-    )
+    prompt_tokens = int(raw_stats.get("inputTokenCount", raw_stats.get("input_tokens", 0)) or 0)
     completion_tokens = int(
         raw_stats.get("outputTokenCount", raw_stats.get("output_tokens", 0)) or 0
     )
@@ -229,7 +227,9 @@ class GeminiCLIProvider(ProviderAdapter):
                 value = os.environ.get(key)
                 if value:
                     env[key] = value
-            has_vertex_project = bool(env.get("GOOGLE_CLOUD_PROJECT") or env.get("GOOGLE_CLOUD_PROJECT_ID"))
+            has_vertex_project = bool(
+                env.get("GOOGLE_CLOUD_PROJECT") or env.get("GOOGLE_CLOUD_PROJECT_ID")
+            )
             has_vertex_location = bool(env.get("GOOGLE_CLOUD_LOCATION"))
             # Gemini CLI's Vertex path will prefer GOOGLE_API_KEY over ADC/project
             # config. Drop the API key when full Vertex project config is available
@@ -401,7 +401,9 @@ class GeminiCLIProvider(ProviderAdapter):
             try:
                 payload = _extract_json_payload(stdout_text)
                 if isinstance(payload, dict) and payload.get("error"):
-                    raise RuntimeError(f"Gemini CLI error: {_format_gemini_error(payload['error'])}")
+                    raise RuntimeError(
+                        f"Gemini CLI error: {_format_gemini_error(payload['error'])}"
+                    )
                 output = _extract_text_payload(payload)
                 if isinstance(payload, dict):
                     usage = _normalize_usage(payload.get("stats"))

--- a/src/llm_council/providers/compiler.py
+++ b/src/llm_council/providers/compiler.py
@@ -100,10 +100,10 @@ def compile_request_for_provider(
 
         if compiled.reasoning and compiled.reasoning.enabled:
             if _openai_supports_reasoning(model):
-                if compiled.reasoning.effort == "none" and model.startswith(REASONING_MODEL_PREFIXES):
-                    update(
-                        reasoning=compiled.reasoning.model_copy(update={"effort": "medium"})
-                    )
+                if compiled.reasoning.effort == "none" and model.startswith(
+                    REASONING_MODEL_PREFIXES
+                ):
+                    update(reasoning=compiled.reasoning.model_copy(update={"effort": "medium"}))
                     decide(
                         "reasoning.effort",
                         "transformed",
@@ -144,9 +144,14 @@ def compile_request_for_provider(
         if compiled.tool_choice is not None:
             update(tool_choice=None)
             decide("tool_choice", "dropped", "Anthropic adapter does not support tool_choice")
-        if compiled.reasoning and compiled.reasoning.enabled and compiled.temperature not in (
-            None,
-            1,
+        if (
+            compiled.reasoning
+            and compiled.reasoning.enabled
+            and compiled.temperature
+            not in (
+                None,
+                1,
+            )
         ):
             update(temperature=1.0)
             decide(
@@ -169,7 +174,11 @@ def compile_request_for_provider(
         if compiled.tool_choice is not None:
             update(tool_choice=None)
             decide("tool_choice", "dropped", "Gemini API adapter does not support tool_choice")
-        if compiled.reasoning and compiled.reasoning.enabled and compiled.reasoning.effort is not None:
+        if (
+            compiled.reasoning
+            and compiled.reasoning.enabled
+            and compiled.reasoning.effort is not None
+        ):
             update(reasoning=compiled.reasoning.model_copy(update={"effort": None}))
             decide("reasoning.effort", "ignored", "Gemini uses thinking_level/budget, not effort")
         if compiled.structured_output:
@@ -213,11 +222,17 @@ def compile_request_for_provider(
         else:
             if compiled.tools:
                 update(tools=None)
-                decide("tools", "dropped", "Vertex Gemini path does not yet forward tool definitions")
+                decide(
+                    "tools", "dropped", "Vertex Gemini path does not yet forward tool definitions"
+                )
             if compiled.tool_choice is not None:
                 update(tool_choice=None)
                 decide("tool_choice", "dropped", "Vertex Gemini path does not support tool_choice")
-            if compiled.reasoning and compiled.reasoning.enabled and compiled.reasoning.effort is not None:
+            if (
+                compiled.reasoning
+                and compiled.reasoning.enabled
+                and compiled.reasoning.effort is not None
+            ):
                 update(reasoning=compiled.reasoning.model_copy(update={"effort": None}))
                 decide(
                     "reasoning.effort",
@@ -343,6 +358,8 @@ def _drop_cli_only_options(
             "dropped",
             f"{provider_label} does not support structured output",
         )
+
+
 def _openai_supports_structured_output(model: str) -> bool:
     return model in OPENAI_STRUCTURED_OUTPUT_MODELS or any(
         model.startswith(prefix) for prefix in OPENAI_STRUCTURED_OUTPUT_MODEL_PREFIXES

--- a/src/llm_council/providers/concurrency.py
+++ b/src/llm_council/providers/concurrency.py
@@ -34,13 +34,17 @@ def _locks_enabled() -> bool:
 
 def _lock_root() -> Path:
     override = os.getenv(_LOCK_DIR_ENV)
-    base = Path(override) if override else Path(tempfile.gettempdir()) / "llm-council-provider-locks"
+    base = (
+        Path(override) if override else Path(tempfile.gettempdir()) / "llm-council-provider-locks"
+    )
     base.mkdir(parents=True, exist_ok=True)
     return base
 
 
 def _lock_path_for_provider(provider_name: str) -> Path:
-    safe_name = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in provider_name)
+    safe_name = "".join(
+        ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in provider_name
+    )
     return _lock_root() / f"{safe_name}.lock"
 
 
@@ -87,9 +91,7 @@ def acquire_provider_call_lease(
             elapsed = time.monotonic() - started
             if timeout_seconds is not None and elapsed >= timeout_seconds:
                 os.close(fd)
-                raise TimeoutError(
-                    f"Timed out waiting for provider slot: {provider_name}"
-                ) from exc
+                raise TimeoutError(f"Timed out waiting for provider slot: {provider_name}") from exc
             time.sleep(poll_interval_seconds)
 
     waited_ms = round((time.monotonic() - started) * 1000, 1)

--- a/src/llm_council/providers/concurrency.py
+++ b/src/llm_council/providers/concurrency.py
@@ -20,7 +20,7 @@ from pathlib import Path
 try:  # pragma: no cover - exercised indirectly on non-POSIX platforms
     import fcntl
 except ImportError:  # pragma: no cover - Windows fallback
-    fcntl = None
+    fcntl = None  # type: ignore[assignment]
 
 _LOCK_DIR_ENV = "LLM_COUNCIL_LOCK_DIR"
 _DISABLE_LOCKS_ENV = "LLM_COUNCIL_DISABLE_PROVIDER_LOCKS"

--- a/src/llm_council/providers/openrouter.py
+++ b/src/llm_council/providers/openrouter.py
@@ -58,9 +58,11 @@ def _schema_is_strict_compatible(schema: Any) -> bool:
     properties = schema.get("properties")
     if schema_type == "object" and isinstance(properties, dict) and properties:
         required = schema.get("required")
-        required_set = {
-            item for item in required if isinstance(item, str)
-        } if isinstance(required, list) else set()
+        required_set = (
+            {item for item in required if isinstance(item, str)}
+            if isinstance(required, list)
+            else set()
+        )
         if required_set != set(properties):
             return False
     if schema_type == "object" and schema.get("additionalProperties") is not False:

--- a/src/llm_council/storage/artifacts.py
+++ b/src/llm_council/storage/artifacts.py
@@ -204,7 +204,11 @@ class ArtifactStore:
             artifact_dir = (
                 Path(artifact_override).expanduser()
                 if artifact_override
-                else (base_home / cls.DEFAULT_ARTIFACT_SUBDIR if base_home else cls._default_artifact_dir())
+                else (
+                    base_home / cls.DEFAULT_ARTIFACT_SUBDIR
+                    if base_home
+                    else cls._default_artifact_dir()
+                )
             )
             db_path = (
                 Path(db_override).expanduser()
@@ -242,7 +246,8 @@ class ArtifactStore:
             default_db_path=cls._default_db_path(),
             legacy_artifact_dir=legacy_artifact_dir,
             legacy_db_path=legacy_db_path,
-            using_legacy=active_artifact_dir == legacy_artifact_dir and active_db_path == legacy_db_path,
+            using_legacy=active_artifact_dir == legacy_artifact_dir
+            and active_db_path == legacy_db_path,
         )
 
     @classmethod
@@ -925,7 +930,9 @@ class ArtifactStore:
                 if path.is_file()
             )
             if source_files != target_files:
-                raise RuntimeError("Artifact migration verification failed: copied file set mismatch.")
+                raise RuntimeError(
+                    "Artifact migration verification failed: copied file set mismatch."
+                )
 
         if source_db_path.exists():
             source_conn = sqlite3.connect(source_db_path)
@@ -937,7 +944,9 @@ class ArtifactStore:
                 source_conn.close()
                 target_conn.close()
             if source_ok != ("ok",) or target_ok != ("ok",):
-                raise RuntimeError("Ledger migration verification failed: SQLite integrity check failed.")
+                raise RuntimeError(
+                    "Ledger migration verification failed: SQLite integrity check failed."
+                )
 
         return StorageMigrationResult(
             source_artifact_dir=source_artifact_dir,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,6 +222,7 @@ class TestCLIDoctor:
 
     def test_doctor_deep_probe_reports_generation_readiness(self):
         """Deep doctor should surface whether a provider can answer a trivial prompt."""
+
         @asynccontextmanager
         async def fake_slot(_name: str, *, timeout_seconds: float | None = None):
             assert timeout_seconds == 5.0
@@ -336,7 +337,10 @@ class TestCLIDoctor:
 
             assert result.exit_code == 0
             assert '"probe_ok": false' in result.stdout
-            assert "OpenRouter probe failed for configured model 'qwen/qwen3.6-plus:free'" in result.stdout
+            assert (
+                "OpenRouter probe failed for configured model 'qwen/qwen3.6-plus:free'"
+                in result.stdout
+            )
             assert "The free model has been deprecated." in result.stdout
             assert "use --models" in result.stdout
 
@@ -788,9 +792,7 @@ class TestMarkdownOutputFormat:
             mock_council_class.return_value = MagicMock()
             mock_run.return_value = mock_result
 
-            result = runner.invoke(
-                app, ["run", "router", "Test task", "--format", "markdown"]
-            )
+            result = runner.invoke(app, ["run", "router", "Test task", "--format", "markdown"])
             assert result.exit_code == 0
             assert "# Council Result: SUCCESS" in result.stdout
             assert "## Metrics" in result.stdout
@@ -832,9 +834,7 @@ class TestMarkdownOutputFormat:
             mock_council_class.return_value = MagicMock()
             mock_run.return_value = mock_result
 
-            result = runner.invoke(
-                app, ["run", "router", "Test task", "--format", "json"]
-            )
+            result = runner.invoke(app, ["run", "router", "Test task", "--format", "json"])
             assert result.exit_code == 0
             assert "Council Result" not in result.stdout
             assert '"success": true' in result.stdout
@@ -852,9 +852,7 @@ class TestMarkdownOutputFormat:
             mock_council_class.return_value = MagicMock()
             mock_run.return_value = self._success_result()
 
-            result = runner.invoke(
-                app, ["run", "router", "Test task", "--format", "yaml"]
-            )
+            result = runner.invoke(app, ["run", "router", "Test task", "--format", "yaml"])
             assert result.exit_code == 1
             assert "Invalid --format" in result.stdout
 
@@ -975,7 +973,14 @@ class TestCLIContextMetadata:
 
             result = runner.invoke(
                 app,
-                ["run", "critic", "Review the benchmark plan", "--files", str(missing_file), "--json"],
+                [
+                    "run",
+                    "critic",
+                    "Review the benchmark plan",
+                    "--files",
+                    str(missing_file),
+                    "--json",
+                ],
             )
 
         assert result.exit_code in [0, 1]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -507,13 +507,9 @@ class TestOrchestratorValidation:
             orch = Orchestrator(providers=["vertex-ai"], config=config)
 
         assert orch._provider_request_timeout_seconds("draft", provider_name="vertex-ai") == 59.0
+        assert orch._provider_request_timeout_seconds("critique", provider_name="vertex-ai") == 45.0
         assert (
-            orch._provider_request_timeout_seconds("critique", provider_name="vertex-ai")
-            == 45.0
-        )
-        assert (
-            orch._provider_request_timeout_seconds("synthesis", provider_name="vertex-ai")
-            == 59.0
+            orch._provider_request_timeout_seconds("synthesis", provider_name="vertex-ai") == 59.0
         )
         assert orch._provider_request_timeout_seconds("draft", provider_name="gemini") == 59.0
         assert orch._provider_request_timeout_seconds("critique", provider_name="gemini") == 45.0
@@ -528,8 +524,12 @@ class TestOrchestratorValidation:
             orch = Orchestrator(providers=["gemini-cli"], config=config)
 
         assert orch._provider_request_timeout_seconds("draft", provider_name="gemini-cli") == 90.0
-        assert orch._provider_request_timeout_seconds("critique", provider_name="gemini-cli") == 60.0
-        assert orch._provider_request_timeout_seconds("synthesis", provider_name="gemini-cli") == 119.0
+        assert (
+            orch._provider_request_timeout_seconds("critique", provider_name="gemini-cli") == 60.0
+        )
+        assert (
+            orch._provider_request_timeout_seconds("synthesis", provider_name="gemini-cli") == 119.0
+        )
 
     def test_bounded_runtime_profile_allows_longer_openai_and_claude_caps(self):
         """OpenAI and Claude get larger bounded caps than the generic profile defaults."""
@@ -1116,9 +1116,10 @@ class TestOrchestratorRuntimeTruthfulness:
         assert decisions["vertex-ai"]["strategy"] == "chunked_context"
         assert decisions["openrouter"]["estimate_method"].startswith("chars_div_4")
         assert decisions["vertex-ai"]["estimate_method"].startswith("chars_div_3.6")
-        assert decisions["openrouter"]["safe_envelope_tokens"] < decisions["vertex-ai"][
-            "safe_envelope_tokens"
-        ]
+        assert (
+            decisions["openrouter"]["safe_envelope_tokens"]
+            < decisions["vertex-ai"]["safe_envelope_tokens"]
+        )
         assert preflight["request_strategy"] == "chunked_context"
 
     def test_prepare_run_warns_when_budget_policy_falls_back_to_default(self):
@@ -1233,7 +1234,9 @@ class TestOrchestratorRuntimeTruthfulness:
             "queue_wait_risk",
         }
         assert orch._execution_plan["draft_execution"]["estimate_method"].startswith("chars_div_4")
-        assert orch._execution_plan["draft_budget_decisions"]["openrouter"]["minimum_chunk_count"] >= 2
+        assert (
+            orch._execution_plan["draft_budget_decisions"]["openrouter"]["minimum_chunk_count"] >= 2
+        )
 
     @pytest.mark.asyncio
     async def test_chunked_openrouter_later_phases_use_normalized_handoff(self):
@@ -1574,8 +1577,7 @@ class TestOrchestratorRuntimeTruthfulness:
         assert result.data["recommendations"]
         assert result.data["issues"][0]["location"]["file"].startswith("docs/research/plan.md")
         assert any(
-            "used conservative reviewer fallback built from chunked draft evidence"
-            in error
+            "used conservative reviewer fallback built from chunked draft evidence" in error
             for error in (result.errors or [])
         )
 
@@ -1623,7 +1625,9 @@ class TestOrchestratorRuntimeTruthfulness:
             orch = Orchestrator(providers=["openrouter"], config=config)
 
         orch._execution_plan = {}
-        orch._provider_init_errors["openrouter"] = "The operation did not complete (read) (_ssl.c:2588)"
+        orch._provider_init_errors["openrouter"] = (
+            "The operation did not complete (read) (_ssl.c:2588)"
+        )
 
         restored = orch._restore_transient_draft_providers(
             {"openrouter": "draft text"},
@@ -1680,7 +1684,10 @@ class TestOrchestratorRuntimeTruthfulness:
         assert "=== FILE:" not in critique_prompt
         assert "=== FILE:" not in synthesis_prompt
         assert orch._execution_plan is not None
-        assert orch._execution_plan["phase_prompt_metrics"]["synthesis"][0]["structured_output"] is True
+        assert (
+            orch._execution_plan["phase_prompt_metrics"]["synthesis"][0]["structured_output"]
+            is True
+        )
 
     @pytest.mark.asyncio
     async def test_run_continues_without_critique_when_critique_fails(self):

--- a/tests/test_provider_concurrency.py
+++ b/tests/test_provider_concurrency.py
@@ -12,7 +12,9 @@ import pytest
 from llm_council.providers.concurrency import acquire_provider_call_lease
 
 
-def _hold_provider_lock(lock_dir: str, provider_name: str, ready_queue: multiprocessing.Queue) -> None:
+def _hold_provider_lock(
+    lock_dir: str, provider_name: str, ready_queue: multiprocessing.Queue
+) -> None:
     os.environ["LLM_COUNCIL_LOCK_DIR"] = lock_dir
     lease = acquire_provider_call_lease(provider_name, timeout_seconds=1.0)
     ready_queue.put("locked")
@@ -26,7 +28,11 @@ def _hold_provider_lock(lock_dir: str, provider_name: str, ready_queue: multipro
 def test_acquire_provider_call_lease_times_out_when_another_process_holds_slot(tmp_path: Path):
     """A second process should not be able to enter the same provider slot immediately."""
 
-    ctx = multiprocessing.get_context("fork") if "fork" in multiprocessing.get_all_start_methods() else multiprocessing
+    ctx = (
+        multiprocessing.get_context("fork")
+        if "fork" in multiprocessing.get_all_start_methods()
+        else multiprocessing
+    )
     ready_queue = ctx.Queue()
     process = ctx.Process(
         target=_hold_provider_lock,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1623,9 +1623,7 @@ class TestOpenRouterProviderEnvModel:
             "additionalProperties": False,
         }
 
-    def test_build_request_body_disables_strict_when_schema_has_optional_properties(
-        self, caplog
-    ):
+    def test_build_request_body_disables_strict_when_schema_has_optional_properties(self, caplog):
         """Optional object fields should keep their semantics instead of being made required."""
         provider = OpenRouterProvider(api_key="sk-or-test")
         schema = {

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -74,7 +74,9 @@ class TestArtifactStore:
             db_path=tmp_path / ".claude" / "council-ledger.db",
         )
         run = legacy_store.create_run(subagent="test", task="legacy")
-        legacy_artifact = legacy_store.store_artifact(run.run_id, "legacy content", ArtifactType.DRAFT)
+        legacy_artifact = legacy_store.store_artifact(
+            run.run_id, "legacy content", ArtifactType.DRAFT
+        )
 
         result = ArtifactStore.migrate_legacy_storage()
 


### PR DESCRIPTION
## Why
CI on `main` has been **red on every push** — and not for one reason. Two gates were failing in sequence:
1. **`ruff format --check`** — 12 files had drifted from ruff's style (lint `ruff check` passed, so it was easy to miss).
2. **`mypy src/` (strict)** — 9 errors in 5 files (the step after ruff).

Because `Publish to PyPI` is **not gated on CI**, v0.7.x releases shipped from this red pipeline. Greening CI also unblocks the stalled security Dependabot PRs (#33/#34/#40).

## What
1. `ruff format src/ tests/` — 12 files reformatted (formatting-only).
2. 9 mypy strict fixes (see commit `d6fad92`): redundant-cast removal, `str | None` coercions at the prompt builders, synthesis lambda → typed named `def` (preserving B023-safe loop-var binding), `json_schema=schema or {}`, contextmanager return annotation, and targeted ignores for the `tomllib`/`fcntl` optional-import fallbacks.

## Verification (exact CI gates, locally)
- `ruff check src/ tests/` → All checks passed
- `ruff format --check src/ tests/` → clean
- `mypy src/` → **Success: no issues found in 43 source files** (was 9 errors)
- `pytest` → **379 passed**

Based on v0.7.17 (68789e5); the `--format markdown` feature is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)