### PR TITLE
ci: gate PyPI/TestPyPI publish on CI passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Allow other workflows (e.g. publish.yml) to require CI as a prerequisite.
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,15 @@ permissions:
   contents: read
 
 jobs:
+  ci:
+    name: CI
+    # Gate: lint, format, mypy, and tests must pass before anything is built
+    # or published. Prevents releases shipping from a red pipeline.
+    uses: ./.github/workflows/ci.yml
+
   build:
     name: Build distribution
+    needs: [ci]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Why
`publish.yml`'s `build` job had **no dependency on CI**, so a release (or push to main) published even when CI was red — which is how v0.7.x shipped from a broken pipeline.

## What
- `ci.yml`: add `workflow_call` trigger so other workflows can require it.
- `publish.yml`: add a `ci` job (`uses: ./.github/workflows/ci.yml`) and make `build` `needs: [ci]`. Since `publish-to-pypi` and `publish-to-testpypi` already `needs: [build]`, **nothing builds or publishes unless lint + format + mypy + tests pass** on the release/main commit.

Validated: both workflows parse; job graph is `ci → build → {publish-pypi, publish-testpypi}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)