### PR TITLE
Release 0.7.18 prompt caching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.18] - 2026-06-10
+
+### Added
+- Cross-provider prompt-cache support with provider-specific behavior instead
+  of a false universal cache switch.
+- Anthropic automatic prompt-cache controls, OpenRouter route-gated
+  `cache_control`, OpenAI cache telemetry parsing, and Gemini/Vertex
+  cached-content lifecycle support.
+- Gemini API and Vertex Gemini cached-content lifecycle handling for create,
+  TTL refresh, expiry recreation, best-effort cleanup, billing warnings, and
+  response metadata.
+- Streaming cached-content cleanup support with a final metadata-only response
+  chunk on successful streams.
+- Live proof for OpenRouter, Gemini API, and Vertex Gemini non-streaming cache
+  paths, plus regression tests for streaming cleanup and partial-output expiry
+  behavior.
+
+### Changed
+- Provider documentation now describes cache request controls separately from
+  observed cache telemetry and live-proof status.
+- Packaged council skill and development guide now target `0.7.18`.
+
+### Fixed
+- Streaming cached-content requests no longer bypass cleanup.
+- Streaming cached-content expiry retry is suppressed after partial output has
+  already been yielded, avoiding duplicated or concatenated streamed content.
+- Created cached-content resources are cleaned up on generation failure when
+  `delete_after=True`.
+
 ## [0.7.17] - 2026-06-01
 
 ### Added
@@ -640,7 +669,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic provider adapters
 - JSON schema validation for subagent outputs
 
-[Unreleased]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.16...HEAD
+[Unreleased]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.18...HEAD
+[0.7.18]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.17...v0.7.18
+[0.7.17]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.16...v0.7.17
 [0.7.16]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.15...v0.7.16
 [0.7.15]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.14...v0.7.15
 [0.7.14]: https://github.com/sherifkozman/the-llm-council/compare/v0.7.13...v0.7.14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Multi-LLM Council Framework (v0.7.17) that orchestrates multiple LLM backends for adversarial debate, cross-validation, and structured decision-making. Published as `the-llm-council` on PyPI.
+Multi-LLM Council Framework (v0.7.18) that orchestrates multiple LLM backends for adversarial debate, cross-validation, structured decision-making, and provider-specific prompt-cache handling. Published as `the-llm-council` on PyPI.
 
 - **Python**: >=3.10 (tested 3.10, 3.11, 3.12)
 - **Build**: hatchling

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ routed handoff, capability planning, and deterministic eval tooling. Those
 capabilities materially extend the package runtime and make the public surface
 more explicit for planning, review, security, and research workflows.
 
+The `0.7.18` release adds provider-specific prompt-cache support. Cache request
+controls are adapter-owned, cache telemetry is normalized when providers return
+it, and Gemini/Vertex cached-content resources can be created, refreshed, and
+cleaned up with explicit lifecycle metadata.
+
 ## Why Use a Council?
 
 Single-model outputs have blind spots. By running multiple models in parallel and having them critique each other, the council:
@@ -84,6 +89,7 @@ Single-model outputs have blind spots. By running multiple models in parallel an
 | **Adversarial Critique** | Built-in critique phase identifies weaknesses and blind spots |
 | **Schema Validation** | JSON schema validation with automatic retry for structured outputs |
 | **Provider Agnostic** | Swap between OpenRouter, direct APIs, or CLI-based providers |
+| **Prompt Cache Support** | Anthropic/OpenRouter controls, OpenAI telemetry, and Gemini/Vertex cached-content lifecycle handling |
 | **Deep Doctor** | `council doctor --deep` checks real non-interactive generation readiness |
 | **Graceful Degradation** | Automatic retry, fallback, and skip strategies for failures |
 | **Artifact Store** | Persistent storage of drafts with tiered summarization |

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ The public package now supports both:
 - the core three-phase council flow
 - a mode-aware execution path with lightweight capability
   planning, routed handoff, and evaluation tooling
+- provider-specific prompt-cache controls and cache telemetry where supported
 
 ## Overview
 
@@ -53,6 +54,12 @@ Swap between providers seamlessly:
 - **Direct APIs** - Anthropic, OpenAI, and Gemini API native SDKs
 - **CLI Providers** - `codex`, `gemini-cli`, and `claude` via local CLIs
 - **Custom Providers** - Plugin architecture via Python entry points
+
+### Prompt Cache Support
+Prompt caching is provider-specific. Anthropic and eligible OpenRouter routes
+receive explicit cache controls, OpenAI exposes cache telemetry when returned by
+the API, and Gemini API / Vertex Gemini support cached-content create, TTL
+refresh, expiry handling, and best-effort cleanup.
 
 ### Deep Doctor
 `council doctor --deep` distinguishes “installed/configured” from “can answer a

--- a/docs/providers/2026-06-09-anthropic-prompt-caching-design.md
+++ b/docs/providers/2026-06-09-anthropic-prompt-caching-design.md
@@ -1,0 +1,197 @@
+# Anthropic Prompt Caching Proof Slice Design
+
+## Goal
+
+Prove prompt-caching support in LLM Council with the smallest provider slice that has explicit request controls and observable usage telemetry: Anthropic automatic prompt caching.
+
+This is not the full multi-provider implementation. It is the proof slice that decides whether the common request, compiler, adapter, and telemetry surfaces are sound enough to expand later.
+
+## Decision
+
+Implement Anthropic first.
+
+Anthropic is the right proof target because it supports top-level `cache_control`, has documented `5m` and `1h` TTL behavior, and returns cache-specific usage fields. OpenAI is automatic and telemetry-only, OpenRouter depends on routed upstream behavior, and Gemini/Vertex Gemini require cached content object lifecycle work. Those are useful follow-ups, but they are weaker first proofs.
+
+## Current Repo Gap
+
+`GenerateRequest` has no cache control field.
+
+`ProviderCapabilities` has no prompt-caching capability.
+
+`compile_request_for_provider()` has no caching decisions.
+
+The Anthropic adapter does not send `cache_control` and does not parse:
+
+- `cache_read_input_tokens`
+- `cache_creation_input_tokens`
+- `usage.cache_creation.ephemeral_5m_input_tokens`
+- `usage.cache_creation.ephemeral_1h_input_tokens`
+
+CLI providers already parse some cached-token usage, but SDK providers do not.
+
+## Provider Research Summary
+
+Anthropic supports two request modes:
+
+- Automatic caching: top-level `cache_control={"type": "ephemeral"}`.
+- Explicit breakpoints: `cache_control` on individual content blocks.
+
+Automatic caching is the proof-slice scope. Explicit breakpoints are deferred because the current `Message.content` shape is mostly plain text, while block-level breakpoints need content-block arrays and clearer breakpoint placement rules.
+
+Anthropic TTL support:
+
+- Default: 5 minutes.
+- Optional: `ttl="1h"`.
+
+Anthropic usage telemetry:
+
+- `input_tokens`
+- `output_tokens`
+- `cache_read_input_tokens`
+- `cache_creation_input_tokens`
+- optional `cache_creation` bucket fields for 5-minute and 1-hour writes.
+
+## Proposed Public Shape
+
+Add a provider-agnostic but conservative cache config:
+
+```python
+class PromptCacheConfig(BaseModel):
+    enabled: bool = True
+    mode: Literal["auto"] = "auto"
+    ttl: Literal["5m", "1h"] = "5m"
+```
+
+Add to `GenerateRequest`:
+
+```python
+prompt_cache: PromptCacheConfig | None = None
+```
+
+This is deliberately smaller than a final multi-provider abstraction. It allows Anthropic automatic caching without claiming support for Gemini cached content objects, OpenAI implicit caching controls, or OpenRouter route guarantees.
+
+## Capability Shape
+
+Add a conservative capability field:
+
+```python
+prompt_caching: Literal["none", "implicit", "explicit", "context_object", "passthrough"] = "none"
+```
+
+For this proof slice:
+
+- Anthropic: `explicit`
+- OpenAI: `implicit`
+- OpenRouter: `passthrough`
+- Gemini: `context_object`
+- Vertex AI: `passthrough`
+- CLI providers: leave unchanged unless current usage parsing needs capability visibility.
+
+The capability field is descriptive. It does not require implementing every provider in this slice.
+
+## Compiler Behavior
+
+For `provider_identity == "anthropic"`:
+
+- Keep `prompt_cache` when `mode == "auto"`.
+- Transform `ttl="5m"` to `{"type": "ephemeral"}` in the adapter.
+- Transform `ttl="1h"` to `{"type": "ephemeral", "ttl": "1h"}` in the adapter.
+- Record a `supported` decision for Anthropic automatic prompt caching.
+
+For other providers in this proof slice:
+
+- Preserve only descriptive capability metadata.
+- Drop `prompt_cache` with a compilation decision unless provider implementation exists.
+- OpenAI should not receive a request mutation because OpenAI prompt caching is automatic.
+- OpenRouter should not receive `cache_control` until route/model handling is implemented.
+- Gemini and Vertex Gemini should not receive `prompt_cache` until cached content lifecycle is implemented.
+
+## Anthropic Adapter Behavior
+
+When `request.prompt_cache` is present:
+
+- Add top-level `cache_control` to the request body. With the currently locked Anthropic SDK, this must be sent through `extra_body={"cache_control": ...}` because `cache_control` is not yet an explicit SDK keyword.
+- Use the existing normal messages/system handling.
+- Do not add block-level `cache_control`.
+- Do not force beta APIs solely for caching.
+- Continue using beta only for existing structured-output or reasoning paths.
+
+Usage parsing should keep current token totals stable:
+
+- `prompt_tokens` should include all input-equivalent tokens:
+  - `input_tokens`
+  - `cache_read_input_tokens`
+  - `cache_creation_input_tokens`
+- `completion_tokens` remains `output_tokens`.
+- `total_tokens` is prompt plus completion.
+
+Add optional normalized cache telemetry keys:
+
+- `cache_read_tokens`
+- `cache_creation_tokens`
+- `cache_creation_5m_tokens`
+- `cache_creation_1h_tokens`
+
+Do not infer a cache hit from latency.
+
+## Proof Criteria
+
+The proof slice is successful when all are true:
+
+- A `GenerateRequest(prompt_cache=PromptCacheConfig(...))` compiles unchanged for Anthropic.
+- The Anthropic adapter sends the expected top-level `cache_control`.
+- Existing non-cache Anthropic requests do not change.
+- Cache usage fields are parsed when present.
+- Missing cache usage fields default to zero or omission without breaking current usage consumers.
+- Unsupported providers either drop the cache config in compiler decisions or leave behavior unchanged.
+
+## Test Plan
+
+Unit tests:
+
+- `PromptCacheConfig` accepts default auto caching and `ttl="1h"`.
+- Invalid modes or TTLs are rejected.
+- Anthropic compiler keeps supported automatic caching.
+- OpenAI/OpenRouter/Gemini/Vertex compiler drops cache config until implemented.
+
+Provider request tests:
+
+- Anthropic request with default TTL sends `cache_control={"type": "ephemeral"}`.
+- Anthropic request with `ttl="1h"` sends `cache_control={"type": "ephemeral", "ttl": "1h"}`.
+- Anthropic request without cache sends no `cache_control`.
+- Structured output and reasoning still select the same beta/non-beta paths as before.
+
+Provider usage tests:
+
+- Anthropic parser extracts read and write cache tokens.
+- Anthropic parser includes cached tokens in `prompt_tokens`.
+- Anthropic parser handles missing `cache_creation` buckets.
+
+Optional live integration:
+
+- Marked separately and skipped by default.
+- Requires `ANTHROPIC_API_KEY`.
+- Sends the same long stable-prefix prompt twice.
+- Asserts only usage telemetry fields, not latency or cost.
+
+## Risks
+
+The main risk is designing a cache abstraction that becomes too broad too early. The proof slice avoids this by supporting only automatic Anthropic caching and by treating other provider shapes as future work.
+
+Anthropic explicit block-level breakpoints are intentionally deferred. They need content block support and placement rules that are not part of the current `Message` model.
+
+OpenRouter should not be treated as equivalent to Anthropic yet. It may pass through cache controls for Claude routes, but route/model/provider behavior can vary.
+
+Gemini context caching is a separate lifecycle feature. It should not be squeezed into the Anthropic proof slice.
+
+## Review Gate
+
+After this proof slice is implemented and tested, run a council review with the changed files and test results.
+
+If council accepts the slice and live telemetry proves useful, write the full implementation and testing plan for:
+
+- OpenAI telemetry parsing
+- OpenRouter passthrough with route safeguards
+- Gemini cached content lifecycle
+- Vertex Claude and Vertex Gemini split paths
+- normalized cache reporting in council execution metadata

--- a/docs/providers/2026-06-09-cross-provider-prompt-caching.md
+++ b/docs/providers/2026-06-09-cross-provider-prompt-caching.md
@@ -1,0 +1,87 @@
+# Cross-Provider Prompt Caching Support
+
+## Summary
+
+Prompt caching is provider-specific in LLM Council. `PromptCacheConfig` is a
+shared request surface, but each adapter owns wire serialization and each
+provider keeps only the cache mode it can actually support.
+
+## Current Support Matrix
+
+| Provider | Support level | Request behavior | Usage telemetry | Live proof |
+| --- | --- | --- | --- | --- |
+| Anthropic | Fully supported for automatic cache controls | Sends `extra_body={"cache_control": {"type": "ephemeral"}}`; includes `ttl="1h"` when requested | Parses `cache_read_input_tokens`, `cache_creation_input_tokens`, and 5m/1h creation buckets | Proven locally with first-call creation and second-call read telemetry |
+| OpenAI | Telemetry-only | Sends no request cache controls because caching is automatic | Parses `usage.prompt_tokens_details.cached_tokens` into `cache_read_tokens` | Deferred; no request controls to prove |
+| OpenRouter | Route-gated passthrough | Sends top-level `cache_control` only for `anthropic/` routes | Parses `prompt_tokens_details.cached_tokens` and `cache_write_tokens` | Proven live on `anthropic/claude-haiku-4.5`: second identical call returned `cache_read_tokens=8116` |
+| Gemini API | Cached-content lifecycle supported | Creates cached-content resources from explicit `source_text`, refreshes TTL, passes `config["cached_content"]`, retries once after expiry, and optionally deletes after generation | Parses `usage_metadata.cached_content_token_count` into `cache_read_tokens`; returns lifecycle metadata and cleanup warnings | Proven live on `gemini-3.1-pro-preview`: created `cachedContents/...`, returned `cache_read_tokens=12603`, and deleted successfully |
+| Vertex Claude | Anthropic-like split path | Sends `extra_body.cache_control` for Claude models | Parses Anthropic-style cache read/write usage | Deferred until Vertex Claude live credentials verify SDK parity |
+| Vertex Gemini | Gemini-like lifecycle supported | Uses the Google GenAI Vertex cache APIs for create, TTL refresh, cached generation, expiry recreation, and cleanup | Parses `usage_metadata.cached_content_token_count`; returns lifecycle metadata and cleanup warnings | Proven live on `gemini-3.1-pro-preview`: created `projects/.../cachedContents/...`, returned `cache_read_tokens=14002`, and deleted successfully |
+| CLI providers | Telemetry preservation only | No prompt-cache request controls in this phase | Existing CLI usage parsing remains provider-owned | Deferred |
+
+## Request Contract
+
+`PromptCacheConfig(mode="auto")` is valid for Anthropic-style automatic cache
+controls. The compiler keeps it for Anthropic and Vertex Claude, and keeps it
+for OpenRouter only when the route model starts with `anthropic/`.
+
+`PromptCacheConfig(mode="cached_content", cached_content_name="cachedContents/...")`
+is valid for Gemini-style reuse of an existing cached-content resource.
+
+`PromptCacheConfig(mode="cached_content", create_if_missing=True, source_text="...")`
+creates a Gemini-style cached-content resource from explicit stable source text.
+The adapter then forwards the returned cache name in generation config.
+
+Optional lifecycle flags:
+
+- `refresh_ttl=True` updates the cached-content TTL before generation.
+- `delete_after=True` performs best-effort cleanup after generation.
+- Expired or missing cached-content resources are recreated once when
+  `create_if_missing=True` and `source_text` is available.
+- Streaming expiry is retried only before any chunk has been yielded. If expiry
+  is detected after partial streamed output, the provider propagates the error
+  after cleanup instead of concatenating partial output with a retried stream.
+- Successful streaming responses include a final metadata-only
+  `GenerateResponse` chunk with cached-content cleanup status.
+
+Created or refreshed cached-content resources can incur provider storage billing
+until TTL expiry or successful cleanup. Cleanup failures are returned as
+warnings and do not hide a successful generation response.
+
+Unsupported providers, unsupported routes, disabled configs, and incompatible
+modes are dropped or ignored by the compiler with explicit request-compilation
+decisions.
+
+## Testing Policy
+
+Unit tests assert request shape and usage telemetry only. They do not assert
+latency or cost.
+
+Execution metadata separates cache intent from cache proof:
+
+- `requested`: the caller supplied an enabled `prompt_cache`.
+- `forwarded`: the compiler preserved `prompt_cache` for adapter serialization.
+- `metrics_available`: the provider returned normalized cache telemetry.
+- `observed`: positive normalized cache telemetry was returned by the provider.
+- `usage`: the positive cache counters observed in the provider response.
+
+`forwarded=True` is not proof of a cache hit. Cache use is only observed when
+the provider response contains positive normalized cache counters.
+
+Live tests must be opt-in and skipped by default. A provider is marked fully
+supported only when its request controls and telemetry are proven live. Providers
+without live proof are documented as telemetry-only, passthrough, cached-content
+passthrough, or deferred.
+
+## Remaining Lifecycle Caveats
+
+Gemini and Vertex Gemini lifecycle handling is intentionally scoped to a single
+request. LLM Council can create, reuse by name, refresh TTL, retry once after
+expiry, and best-effort delete. It does not yet provide a shared cache registry,
+cross-process locking, or automatic reuse discovery.
+
+Live proof has been captured for OpenRouter, Gemini API, and Vertex Gemini on
+non-streaming generation paths. Streaming lifecycle behavior is covered by
+regression tests and still needs separate live proof before being called
+production-proven.
+Vertex Claude still needs separate live proof because it uses the Anthropic
+Vertex SDK path, not the Google GenAI cached-content lifecycle.

--- a/docs/providers/creating-providers.md
+++ b/docs/providers/creating-providers.md
@@ -574,6 +574,33 @@ See existing implementations:
 | Anthropic | `thinking` | `{type: "enabled", budget_tokens: 1024-128000}` + beta API |
 | Gemini API | `thinking_config` | `{thinking_level: "HIGH"}` or `{thinking_budget: 0-24576}` |
 
+### Prompt Caching
+
+Prompt caching is not a universal provider switch. The compiler decides whether
+to keep or drop `PromptCacheConfig`; adapters own the final wire format.
+Execution metadata distinguishes cache controls that were requested or forwarded
+from cache use that was actually observed in provider response telemetry.
+
+| Provider | Cache mode | Wire format |
+|----------|------------|-------------|
+| Anthropic | `auto` | `extra_body={"cache_control": {"type": "ephemeral"}}` |
+| OpenAI | Telemetry-only | No request mutation; parse `prompt_tokens_details.cached_tokens` |
+| OpenRouter | `auto` for allowlisted routes | Top-level `cache_control` only for `anthropic/*` routes |
+| Gemini API | `cached_content` | Create/reuse `cachedContents/...`, pass `config["cached_content"]`, refresh TTL, and optionally delete |
+| Vertex AI | Split path | Claude mirrors Anthropic; Gemini uses Vertex cached-content lifecycle APIs |
+
+Gemini-style cached content has an object lifecycle. `create_if_missing=True`
+requires explicit stable `source_text`, `refresh_ttl=True` updates the TTL
+before generation, and `delete_after=True` performs best-effort cleanup after
+generation. Cleanup warnings are returned in response metadata because cached
+content can incur storage-duration billing until TTL expiry or successful
+delete.
+
+Streaming cached-content requests retry expiry only before any chunk is yielded.
+After partial streamed output, expiry is propagated after cleanup to avoid
+duplicated or concatenated output. Successful streams include a final
+metadata-only response chunk containing cached-content cleanup status.
+
 ## Next Steps
 
 - [OpenRouter Quickstart](../quickstart/openrouter.md)

--- a/docs/quickstart/direct-apis.md
+++ b/docs/quickstart/direct-apis.md
@@ -220,6 +220,38 @@ Available models:
 - `gemini-3.1-pro-preview` - Most capable (recommended)
 - `gemini-3-flash-preview` - Fast and affordable
 
+### Prompt Cache Lifecycle
+
+Gemini prompt caching uses cached-content resources, not Anthropic-style inline
+cache markers. LLM Council can create a resource from explicit stable context,
+use it for generation, refresh its TTL, and delete it after the request:
+
+```python
+from llm_council.providers.base import GenerateRequest, PromptCacheConfig
+from llm_council.providers.gemini import GeminiProvider
+
+provider = GeminiProvider()
+response = await provider.generate(
+    GenerateRequest(
+        prompt="Answer using the cached context.",
+        prompt_cache=PromptCacheConfig(
+            mode="cached_content",
+            create_if_missing=True,
+            source_text="Long stable reference material...",
+            refresh_ttl=True,
+            delete_after=True,
+        ),
+    )
+)
+
+print(response.usage)
+print(response.prompt_cache)
+```
+
+Created or refreshed cached-content resources may incur storage-duration billing
+until TTL expiry or successful cleanup. Streaming responses include a final
+metadata-only chunk with cleanup status.
+
 ## Vertex AI (Enterprise GCP)
 
 Vertex AI provides enterprise access to Gemini and Claude models through Google Cloud with unified billing and IAM.
@@ -306,6 +338,15 @@ asyncio.run(main())
 - `claude-haiku-4-5@20250929` - Fast Claude
 
 **Note:** Claude models require version suffix (e.g., `@20251101`).
+
+### Vertex Gemini Prompt Cache Lifecycle
+
+Vertex Gemini uses the same cached-content lifecycle shape as the Gemini API,
+but resource names are scoped to the Google Cloud project and location, for
+example `projects/.../locations/.../cachedContents/...`. Use
+`PromptCacheConfig(mode="cached_content", ...)` with `create_if_missing`,
+`refresh_ttl`, or `delete_after` when you want Council to manage that resource
+for a request.
 
 ### When to Use Vertex AI vs Direct APIs
 

--- a/docs/quickstart/openrouter.md
+++ b/docs/quickstart/openrouter.md
@@ -327,7 +327,9 @@ if result.cost_estimate:
 1. **Use cheaper models** - `claude-haiku-4-5` instead of `claude-opus-4-6`
 2. **Reduce token limits** - Lower `max_tokens` in config
 3. **Disable parallel drafts** - Use single provider mode
-4. **Use caching** - OpenRouter supports prompt caching for repeated requests
+4. **Use route-gated caching** - LLM Council only sends OpenRouter prompt-cache
+   controls for explicitly supported cache-capable routes such as `anthropic/*`;
+   other routes continue without cache controls.
 
 ### Example: Budget-Conscious Config
 

--- a/docs/releases/0.7.18.md
+++ b/docs/releases/0.7.18.md
@@ -1,0 +1,47 @@
+# LLM Council 0.7.18 Release Notes
+
+## Highlights
+
+- Added provider-specific prompt-cache support without pretending every provider
+  uses the same cache model.
+- Added Gemini API and Vertex Gemini cached-content lifecycle handling:
+  create, TTL refresh, expiry recreation, best-effort cleanup, billing warnings,
+  and response metadata.
+- Added OpenRouter route-gated prompt-cache passthrough for eligible Anthropic
+  routes.
+- Added OpenAI cache telemetry parsing without sending unsupported request
+  controls.
+
+## Live Proof
+
+- OpenRouter live proof returned `cache_read_tokens=8116` on the second
+  identical call through an Anthropic route.
+- Gemini API live proof created `cachedContents/...`, returned
+  `cache_read_tokens=12603`, and deleted the resource successfully.
+- Vertex Gemini live proof created `projects/.../cachedContents/...`, returned
+  `cache_read_tokens=14002`, and deleted the resource successfully.
+
+Live proof currently covers non-streaming generation paths. Streaming
+cached-content lifecycle behavior is covered by regression tests and documented
+with a stricter safety contract: retry expiry only before any chunk is yielded,
+then emit final cleanup metadata on successful streams.
+
+## Upgrade Notes
+
+- Install all provider SDKs with:
+
+```bash
+pip install 'the-llm-council[all]>=0.7.18'
+```
+
+- Gemini/Vertex cached-content creation requires explicit stable `source_text`;
+  Council does not infer cacheable source content from dynamic prompts.
+- Created or refreshed cached-content resources can incur storage-duration
+  billing until TTL expiry or successful cleanup.
+
+## Validation
+
+- Focused cached-content lifecycle tests: `28 passed`.
+- Broader prompt-cache suite: `157 passed`.
+- Full suite: `431 passed`.
+- Final council review: approved with no blocking issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "the-llm-council"
-version = "0.7.17"
+version = "0.7.18"
 description = "Multi-LLM Council Framework for adversarial debate, cross-validation, and structured decision-making"
 readme = "README.md"
 license = "MIT"

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -3,7 +3,7 @@ name: council
 description: Run multi-LLM council for adversarial debate and cross-validation. Use it for implementation, architecture, review, security, research, and planning tasks with the canonical llm-council subagents and modes.
 ---
 
-# LLM Council Skill (v0.7.17)
+# LLM Council Skill (v0.7.18)
 
 Multi-model council: parallel drafts, adversarial critique, validated synthesis.
 
@@ -16,14 +16,14 @@ Multi-model council: parallel drafts, adversarial critique, validated synthesis.
 Install the package:
 
 ```bash
-pip install 'the-llm-council>=0.7.17'
+pip install 'the-llm-council>=0.7.18'
 ```
 
 Optional extras:
 
 ```bash
-pip install 'the-llm-council[anthropic,openai,gemini]>=0.7.17'
-pip install 'the-llm-council[vertex]>=0.7.17'
+pip install 'the-llm-council[anthropic,openai,gemini]>=0.7.18'
+pip install 'the-llm-council[vertex]>=0.7.18'
 ```
 
 Configure at least one provider key:

--- a/src/llm_council/engine/capabilities.py
+++ b/src/llm_council/engine/capabilities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeGuard
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -35,6 +35,14 @@ _BUDGET_CLASS_ORDER: dict[BudgetClass, int] = {
     "normal": 1,
     "premium": 2,
 }
+
+
+def _is_execution_profile(value: str | None) -> TypeGuard[ExecutionProfile]:
+    return value in _EXECUTION_PROFILE_ORDER
+
+
+def _is_budget_class(value: str | None) -> TypeGuard[BudgetClass]:
+    return value in _BUDGET_CLASS_ORDER
 
 
 _CAPABILITY_POLICY: dict[tuple[str, str | None], CapabilityPlan] = {
@@ -197,9 +205,7 @@ def _apply_capability_overrides(
     """
 
     normalized_execution_profile = (
-        requested_execution_profile
-        if requested_execution_profile in _EXECUTION_PROFILE_ORDER
-        else None
+        requested_execution_profile if _is_execution_profile(requested_execution_profile) else None
     )
     if normalized_execution_profile is not None:
         if (
@@ -209,7 +215,7 @@ def _apply_capability_overrides(
             plan.execution_profile = normalized_execution_profile
 
     normalized_budget_class = (
-        requested_budget_class if requested_budget_class in _BUDGET_CLASS_ORDER else None
+        requested_budget_class if _is_budget_class(requested_budget_class) else None
     )
     if normalized_budget_class is not None:
         if _BUDGET_CLASS_ORDER[normalized_budget_class] > _BUDGET_CLASS_ORDER[plan.budget_class]:

--- a/src/llm_council/engine/orchestrator.py
+++ b/src/llm_council/engine/orchestrator.py
@@ -87,6 +87,12 @@ _CHUNKING_TARGET_CHARS = 60_000
 _CHUNKED_DRAFT_MAX_TOKENS = 900
 _LARGE_SINGLE_RUN_WARNING_TOKENS = 12_000
 _DEFAULT_ESTIMATE_METHOD = "chars_div_4_padded"
+_CACHE_USAGE_KEYS = (
+    "cache_read_tokens",
+    "cache_creation_tokens",
+    "cache_creation_5m_tokens",
+    "cache_creation_1h_tokens",
+)
 _PHASE_PROMPT_PROFILES: dict[str, list[dict[str, int | None]]] = {
     "critique": [
         {
@@ -1198,6 +1204,7 @@ class Orchestrator:
                     usage = dict(chunk.usage)
             return GenerateResponse(text="".join(text_parts), usage=usage)
 
+        prompt_cache_requested = bool(request.prompt_cache and request.prompt_cache.enabled)
         compiled = compile_request_for_provider(provider_name, request)
         self._record_request_compilation(
             phase=phase,
@@ -1205,6 +1212,7 @@ class Orchestrator:
             compilation=compiled.to_dict(),
         )
         request = compiled.request
+        prompt_cache_forwarded = bool(request.prompt_cache and request.prompt_cache.enabled)
 
         while True:
             try:
@@ -1233,6 +1241,13 @@ class Orchestrator:
                         )
 
                 self._record_usage(provider_name, response.usage)
+                self._record_prompt_cache_observation(
+                    phase=phase,
+                    provider_name=provider_name,
+                    requested=prompt_cache_requested,
+                    forwarded=prompt_cache_forwarded,
+                    usage=response.usage,
+                )
                 return response
 
             except Exception as exc:
@@ -2466,6 +2481,60 @@ class Orchestrator:
         completion_tokens = usage.get("completion_tokens") or usage.get("output_tokens") or 0
         self._input_tokens[provider] = self._input_tokens.get(provider, 0) + prompt_tokens
         self._output_tokens[provider] = self._output_tokens.get(provider, 0) + completion_tokens
+        self._record_cache_usage(provider, usage)
+
+    def _record_cache_usage(self, provider: str, usage: Mapping[str, int]) -> None:
+        """Accumulate normalized cache-token fields in execution metadata."""
+
+        if self._execution_plan is None:
+            return
+
+        cache_usage: dict[str, int] = {}
+        for key in _CACHE_USAGE_KEYS:
+            value = usage.get(key)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                cache_usage[key] = value
+
+        if not cache_usage:
+            return
+
+        provider_cache = self._execution_plan.setdefault("cache_usage", {}).setdefault(provider, {})
+        for key, value in cache_usage.items():
+            provider_cache[key] = provider_cache.get(key, 0) + value
+
+    def _record_prompt_cache_observation(
+        self,
+        *,
+        phase: str | None,
+        provider_name: str,
+        requested: bool,
+        forwarded: bool,
+        usage: Mapping[str, int] | None,
+    ) -> None:
+        """Record request-vs-observed prompt-cache state for one provider call."""
+
+        if self._execution_plan is None or not (requested or forwarded or usage):
+            return
+
+        cache_usage: dict[str, int] = {}
+        if usage:
+            for key in _CACHE_USAGE_KEYS:
+                value = usage.get(key)
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    cache_usage[key] = value
+
+        entry: dict[str, Any] = {
+            "provider": provider_name,
+            "requested": requested,
+            "forwarded": forwarded,
+            "metrics_available": bool(cache_usage),
+            "observed": bool(cache_usage),
+        }
+        if cache_usage:
+            entry["usage"] = cache_usage
+
+        observations = self._execution_plan.setdefault("prompt_cache_observations", {})
+        observations.setdefault(phase or "unknown", []).append(entry)
 
     def _estimate_input_tokens(self, *parts: str) -> int:
         """Return a lightweight token estimate for prompt diagnostics."""

--- a/src/llm_council/providers/anthropic.py
+++ b/src/llm_council/providers/anthropic.py
@@ -152,6 +152,7 @@ class AnthropicProvider(ProviderAdapter):
         structured_output=True,
         multimodal=True,
         max_tokens=8192,
+        prompt_caching="explicit",
     )
 
     def __init__(
@@ -223,6 +224,10 @@ class AnthropicProvider(ProviderAdapter):
             kwargs["stop_sequences"] = list(request.stop)
         if request.tools:
             kwargs["tools"] = list(request.tools)
+        cache_control = self._cache_control_for_request(request)
+        if cache_control is not None:
+            # anthropic 0.75.0 does not expose cache_control as a typed keyword yet.
+            kwargs["extra_body"] = {"cache_control": cache_control}
 
         # Handle structured output - requires beta header and output_format
         # See: https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs
@@ -362,6 +367,17 @@ class AnthropicProvider(ProviderAdapter):
         # Check if model starts with any supported prefix (Claude 4.x family)
         return any(model.startswith(prefix) for prefix in STRUCTURED_OUTPUT_MODEL_PREFIXES)
 
+    def _cache_control_for_request(self, request: GenerateRequest) -> dict[str, str] | None:
+        """Build Anthropic top-level automatic cache control."""
+
+        if request.prompt_cache is None or not request.prompt_cache.enabled:
+            return None
+
+        cache_control = {"type": "ephemeral"}
+        if request.prompt_cache.ttl == "1h":
+            cache_control["ttl"] = "1h"
+        return cache_control
+
     def _parse_response(self, response: Any) -> GenerateResponse:
         """Parse Anthropic API response."""
         text = ""
@@ -384,12 +400,32 @@ class AnthropicProvider(ProviderAdapter):
         usage = None
         if hasattr(response, "usage") and response.usage:
             input_tokens = response.usage.input_tokens or 0
+            cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
             output_tokens = response.usage.output_tokens or 0
+            prompt_tokens = input_tokens + cache_read_tokens + cache_creation_tokens
             usage = {
-                "prompt_tokens": input_tokens,
+                "prompt_tokens": prompt_tokens,
                 "completion_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
+                "total_tokens": prompt_tokens + output_tokens,
             }
+            if cache_read_tokens:
+                usage["cache_read_tokens"] = cache_read_tokens
+            if cache_creation_tokens:
+                usage["cache_creation_tokens"] = cache_creation_tokens
+
+            cache_creation = getattr(response.usage, "cache_creation", None)
+            if cache_creation is not None:
+                cache_creation_5m_tokens = (
+                    getattr(cache_creation, "ephemeral_5m_input_tokens", 0) or 0
+                )
+                cache_creation_1h_tokens = (
+                    getattr(cache_creation, "ephemeral_1h_input_tokens", 0) or 0
+                )
+                if cache_creation_5m_tokens:
+                    usage["cache_creation_5m_tokens"] = cache_creation_5m_tokens
+                if cache_creation_1h_tokens:
+                    usage["cache_creation_1h_tokens"] = cache_creation_1h_tokens
 
         return GenerateResponse(
             text=text,
@@ -403,9 +439,7 @@ class AnthropicProvider(ProviderAdapter):
 
     async def supports(self, capability: str) -> bool:
         """Check if the provider supports a capability."""
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         """Perform a health check on the Anthropic API."""

--- a/src/llm_council/providers/base.py
+++ b/src/llm_council/providers/base.py
@@ -210,10 +210,23 @@ class ProviderCapabilities(BaseModel):
     max_tokens: int | None = Field(
         default=None, description="Maximum tokens per response if enforced by the provider."
     )
+    prompt_caching: Literal["none", "implicit", "explicit", "context_object", "passthrough"] = (
+        Field(
+            default="none",
+            description=(
+                "Prompt-cache support shape: none, implicit, explicit, context_object, or passthrough."
+            ),
+        )
+    )
 
 
 ProviderCapabilityName = Literal[
-    "streaming", "tool_use", "structured_output", "multimodal", "max_tokens"
+    "streaming",
+    "tool_use",
+    "structured_output",
+    "multimodal",
+    "max_tokens",
+    "prompt_caching",
 ]
 
 
@@ -248,6 +261,77 @@ class StructuredOutputConfig(BaseModel):
         default=True,
         description="Enforce strict schema adherence where supported.",
     )
+
+
+class PromptCacheConfig(BaseModel):
+    """Configuration for provider-managed prompt caching.
+
+    Automatic cache controls are used by Anthropic-style providers. Cached-content
+    mode targets Google Gemini/Vertex cached-content resources. Callers may
+    provide an existing resource name or ask the adapter to create a temporary
+    resource from explicit stable source text.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable provider-managed prompt caching for this request.",
+    )
+    mode: Literal["auto", "cached_content"] = Field(
+        default="auto",
+        description="Prompt-cache mode. cached_content requires cached_content_name.",
+    )
+    ttl: Literal["5m", "1h"] = Field(
+        default="5m",
+        description="Requested cache lifetime where supported.",
+    )
+    cached_content_name: str | None = Field(
+        default=None,
+        description="Provider cache resource name for Gemini/Vertex cached-content mode.",
+    )
+    create_if_missing: bool = Field(
+        default=False,
+        description="Create a cached-content resource when cached_content_name is absent.",
+    )
+    refresh_ttl: bool = Field(
+        default=False,
+        description="Refresh cached-content TTL before generation where supported.",
+    )
+    delete_after: bool = Field(
+        default=False,
+        description="Best-effort delete of the cached-content resource after generation.",
+    )
+    source_text: str | None = Field(
+        default=None,
+        description="Stable source text used when creating a cached-content resource.",
+    )
+    display_name: str | None = Field(
+        default=None,
+        description="Optional provider display name for created cached-content resources.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_cached_content(self) -> PromptCacheConfig:
+        if self.mode == "cached_content":
+            if self.cached_content_name and "cachedContents/" not in self.cached_content_name:
+                raise ValueError("cached_content_name must be a cachedContents resource name.")
+            if self.create_if_missing and not self.source_text:
+                raise ValueError("cached_content create_if_missing requires explicit source_text.")
+            if not self.cached_content_name and not self.create_if_missing:
+                raise ValueError(
+                    "cached_content mode requires cached_content_name or create_if_missing."
+                )
+        elif (
+            self.cached_content_name is not None
+            or self.create_if_missing
+            or self.refresh_ttl
+            or self.delete_after
+            or self.source_text is not None
+            or self.display_name is not None
+        ):
+            raise ValueError("cached-content lifecycle fields require mode='cached_content'.")
+        return self
 
 
 class ReasoningConfig(BaseModel):
@@ -316,6 +400,12 @@ class GenerateRequest(BaseModel):
             "Structured output configuration. Each provider transforms this to their native format."
         ),
     )
+    prompt_cache: PromptCacheConfig | None = Field(
+        default=None,
+        description=(
+            "Optional provider-managed prompt-cache request. Only implemented providers honor it."
+        ),
+    )
     reasoning: ReasoningConfig | None = Field(
         default=None,
         description=(
@@ -350,6 +440,10 @@ class GenerateResponse(BaseModel):
     model: str | None = Field(default=None, description="Resolved model identifier.")
     finish_reason: str | None = Field(default=None, description="Stop reason.")
     raw: Any | None = Field(default=None, description="Raw provider response for debugging.")
+    prompt_cache: Mapping[str, Any] | None = Field(
+        default=None,
+        description="Provider prompt-cache lifecycle metadata, when returned by the adapter.",
+    )
 
 
 GenerateResult = GenerateResponse | AsyncIterator[GenerateResponse]
@@ -383,6 +477,8 @@ class ProviderAdapter(ABC):
       corresponding flag is ``True``.
     - ``max_tokens`` is treated as supported when it is not ``None``
       (i.e. the provider exposes a known limit).
+    - ``prompt_caching`` is treated as supported when its support shape is
+      not ``"none"``.
     """
 
     name: ClassVar[str]
@@ -430,4 +526,6 @@ class ProviderAdapter(ABC):
             return False
         if capability_name == "max_tokens":
             return cls.capabilities.max_tokens is not None
+        if capability_name == "prompt_caching":
+            return cls.capabilities.prompt_caching != "none"
         return bool(getattr(cls.capabilities, capability_name, False))

--- a/src/llm_council/providers/cli/claude_code.py
+++ b/src/llm_council/providers/cli/claude_code.py
@@ -265,9 +265,7 @@ class ClaudeCodeCLIProvider(ProviderAdapter):
         )
 
     async def supports(self, capability: str) -> bool:
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         if not self._cli_path:

--- a/src/llm_council/providers/cli/codex.py
+++ b/src/llm_council/providers/cli/codex.py
@@ -691,9 +691,7 @@ class CodexCLIProvider(ProviderAdapter):
                 shutil.rmtree(cli_home, ignore_errors=True)
 
     async def supports(self, capability: str) -> bool:
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         if not self._cli_path:

--- a/src/llm_council/providers/cli/gemini_cli.py
+++ b/src/llm_council/providers/cli/gemini_cli.py
@@ -427,9 +427,7 @@ class GeminiCLIProvider(ProviderAdapter):
             shutil.rmtree(cli_home, ignore_errors=True)
 
     async def supports(self, capability: str) -> bool:
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         if not self._cli_path:

--- a/src/llm_council/providers/compiler.py
+++ b/src/llm_council/providers/compiler.py
@@ -30,7 +30,12 @@ from llm_council.providers.openai import (
 from llm_council.providers.openai import (
     STRUCTURED_OUTPUT_MODELS as OPENAI_STRUCTURED_OUTPUT_MODELS,
 )
-from llm_council.providers.openrouter import _prepare_structured_output_schema
+from llm_council.providers.openrouter import (
+    _prepare_structured_output_schema,
+)
+from llm_council.providers.openrouter import (
+    _supports_cache_control_model as _openrouter_supports_cache_control_model,
+)
 from llm_council.providers.registry import provider_identity
 from llm_council.providers.vertex import CLAUDE_MODEL_PREFIXES
 
@@ -92,6 +97,92 @@ def compile_request_for_provider(
 
     def decide(option: str, action: CompilationAction, detail: str) -> None:
         decisions.append(CompilationDecision(option=option, action=action, detail=detail))
+
+    if compiled.prompt_cache is not None:
+        if not compiled.prompt_cache.enabled:
+            update(prompt_cache=None)
+            decide("prompt_cache", "ignored", "Prompt cache config is disabled")
+        elif identity == "anthropic":
+            if compiled.prompt_cache.mode == "auto":
+                decide("prompt_cache", "supported", "Anthropic supports automatic prompt caching")
+            else:
+                update(prompt_cache=None)
+                decide(
+                    "prompt_cache",
+                    "dropped",
+                    "Anthropic prompt caching supports only automatic cache controls",
+                )
+        elif identity == "openrouter":
+            route_model = model or provider_name
+            if compiled.prompt_cache.mode != "auto":
+                update(prompt_cache=None)
+                decide(
+                    "prompt_cache",
+                    "dropped",
+                    "OpenRouter prompt caching supports only automatic cache controls",
+                )
+            elif _openrouter_supports_cache_control_model(route_model):
+                decide(
+                    "prompt_cache",
+                    "supported",
+                    "OpenRouter route is in the cache-control allowlist",
+                )
+            else:
+                update(prompt_cache=None)
+                decide(
+                    "prompt_cache",
+                    "dropped",
+                    "OpenRouter prompt caching is route-dependent; model is not in cache-control allowlist",
+                )
+        elif identity == "gemini":
+            if compiled.prompt_cache.mode == "cached_content":
+                decide(
+                    "prompt_cache",
+                    "supported",
+                    "Gemini supports cached-content resource passthrough",
+                )
+            else:
+                update(prompt_cache=None)
+                decide(
+                    "prompt_cache",
+                    "dropped",
+                    "Gemini request caching requires cached-content mode",
+                )
+        elif identity == "vertex-ai":
+            if _vertex_is_claude_model(model):
+                if compiled.prompt_cache.mode == "auto":
+                    decide(
+                        "prompt_cache",
+                        "supported",
+                        "Vertex Claude path supports automatic cache controls",
+                    )
+                else:
+                    update(prompt_cache=None)
+                    decide(
+                        "prompt_cache",
+                        "dropped",
+                        "Vertex Claude path supports only automatic cache controls",
+                    )
+            elif compiled.prompt_cache.mode == "cached_content":
+                decide(
+                    "prompt_cache",
+                    "supported",
+                    "Vertex Gemini path supports cached-content resource passthrough",
+                )
+            else:
+                update(prompt_cache=None)
+                decide(
+                    "prompt_cache",
+                    "dropped",
+                    "Vertex Gemini path requires cached-content mode",
+                )
+        else:
+            update(prompt_cache=None)
+            decide(
+                "prompt_cache",
+                "dropped",
+                f"{provider_name} prompt caching is not implemented in the Anthropic proof slice",
+            )
 
     if identity == "openai":
         if compiled.temperature is not None and not _openai_supports_temperature(model):

--- a/src/llm_council/providers/gemini.py
+++ b/src/llm_council/providers/gemini.py
@@ -7,11 +7,12 @@ Direct integration with the Gemini API via Google's ``google-genai`` SDK.
 from __future__ import annotations
 
 import contextlib
+import inspect
 import logging
 import os
 import time
 from collections.abc import AsyncIterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from llm_council.providers.base import (
     DoctorResult,
@@ -140,6 +141,36 @@ def _strip_schema_meta_fields(
 logger = logging.getLogger(__name__)
 
 
+def _positive_int(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
+
+
+def _cache_ttl_seconds(ttl: str) -> str:
+    return "3600s" if ttl == "1h" else "300s"
+
+
+def _cache_billing_warning() -> str:
+    return (
+        "Gemini cached-content resources can incur storage-duration billing until "
+        "TTL expiry or successful cleanup."
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _is_cached_content_expiry_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "cached" in message and (
+        "expired" in message or "not found" in message or "404" in message
+    )
+
+
 class GeminiProvider(ProviderAdapter):
     """Gemini API provider adapter.
 
@@ -245,6 +276,116 @@ class GeminiProvider(ProviderAdapter):
             self._client = self._build_client(timeout_ms=resolved_timeout)
         return self._client
 
+    def _cache_client(self, client: Any) -> Any:
+        aio_client = getattr(client, "aio", None)
+        caches = getattr(aio_client, "caches", None)
+        if caches is not None:
+            return caches
+        return client.caches
+
+    def _cache_create_config(self, request: GenerateRequest) -> dict[str, Any]:
+        prompt_cache = request.prompt_cache
+        if prompt_cache is None or prompt_cache.source_text is None:
+            raise ValueError("cached-content creation requires source_text.")
+
+        config: dict[str, Any] = {
+            "contents": prompt_cache.source_text,
+            "ttl": _cache_ttl_seconds(prompt_cache.ttl),
+        }
+        if prompt_cache.display_name:
+            config["display_name"] = prompt_cache.display_name
+        return config
+
+    async def _create_cached_content(
+        self, client: Any, model: str, request: GenerateRequest
+    ) -> str:
+        cache = await _maybe_await(
+            self._cache_client(client).create(
+                model=model,
+                config=self._cache_create_config(request),
+            )
+        )
+        cache_name = getattr(cache, "name", None)
+        if not cache_name:
+            raise ValueError("cached-content create response did not include a resource name.")
+        return cast(str, cache_name)
+
+    async def _refresh_cached_content_ttl(
+        self, client: Any, cache_name: str, request: GenerateRequest
+    ) -> None:
+        prompt_cache = request.prompt_cache
+        if prompt_cache is None:
+            return
+        await _maybe_await(
+            self._cache_client(client).update(
+                name=cache_name,
+                config={"ttl": _cache_ttl_seconds(prompt_cache.ttl)},
+            )
+        )
+
+    async def _delete_cached_content(self, client: Any, cache_name: str) -> None:
+        await _maybe_await(self._cache_client(client).delete(name=cache_name))
+
+    def _new_cache_metadata(self, cache_name: str | None) -> dict[str, Any]:
+        return {
+            "cache_name": cache_name,
+            "created": False,
+            "refreshed": False,
+            "deleted": None,
+            "recreated_after_expiry": False,
+            "warnings": [],
+            "billing_warning": _cache_billing_warning(),
+        }
+
+    async def _prepare_cached_content(
+        self,
+        client: Any,
+        model: str,
+        request: GenerateRequest,
+        config: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        prompt_cache = request.prompt_cache
+        if (
+            prompt_cache is None
+            or not prompt_cache.enabled
+            or prompt_cache.mode != "cached_content"
+        ):
+            return None
+
+        metadata = self._new_cache_metadata(prompt_cache.cached_content_name)
+        cache_name = prompt_cache.cached_content_name
+        if not cache_name and prompt_cache.create_if_missing:
+            cache_name = await self._create_cached_content(client, model, request)
+            metadata["cache_name"] = cache_name
+            metadata["created"] = True
+
+        if cache_name and prompt_cache.refresh_ttl:
+            try:
+                await self._refresh_cached_content_ttl(client, cache_name, request)
+                metadata["refreshed"] = True
+            except Exception as exc:
+                metadata["warnings"].append(f"ttl refresh failed: {exc}")
+
+        if cache_name:
+            config["cached_content"] = cache_name
+        return metadata
+
+    async def _cleanup_cached_content(
+        self, client: Any, request: GenerateRequest, metadata: dict[str, Any] | None
+    ) -> None:
+        prompt_cache = request.prompt_cache
+        if metadata is None or prompt_cache is None or not prompt_cache.delete_after:
+            return
+        cache_name = metadata.get("cache_name")
+        if not cache_name:
+            return
+        try:
+            await self._delete_cached_content(client, str(cache_name))
+            metadata["deleted"] = True
+        except Exception as exc:
+            metadata["deleted"] = False
+            metadata["warnings"].append(f"cleanup failed: {exc}")
+
     async def generate(
         self, request: GenerateRequest
     ) -> GenerateResponse | AsyncIterator[GenerateResponse]:
@@ -275,6 +416,7 @@ class GeminiProvider(ProviderAdapter):
             config["top_p"] = request.top_p
         if request.stop:
             config["stop_sequences"] = list(request.stop)
+        cache_metadata = await self._prepare_cached_content(client, model, request, config)
 
         # Handle structured output - requires response_mime_type and response_schema
         # See: https://ai.google.dev/gemini-api/docs/structured-output
@@ -318,15 +460,92 @@ class GeminiProvider(ProviderAdapter):
                 }
 
         if request.stream:
-            return self._generate_stream(client, model, contents, config)
+            return self._generate_stream_with_cache_lifecycle(
+                client, model, contents, config, request, cache_metadata
+            )
 
         # Use async client for generate_content
-        response = await client.aio.models.generate_content(
-            model=model,
-            contents=contents,
-            config=config if config else None,
-        )
-        return self._parse_response(response)
+        try:
+            try:
+                response = await client.aio.models.generate_content(
+                    model=model,
+                    contents=contents,
+                    config=config if config else None,
+                )
+            except Exception as exc:
+                prompt_cache = request.prompt_cache
+                if (
+                    cache_metadata is not None
+                    and prompt_cache is not None
+                    and prompt_cache.create_if_missing
+                    and prompt_cache.source_text
+                    and _is_cached_content_expiry_error(exc)
+                ):
+                    cache_name = await self._create_cached_content(client, model, request)
+                    cache_metadata["cache_name"] = cache_name
+                    cache_metadata["created"] = True
+                    cache_metadata["recreated_after_expiry"] = True
+                    cache_metadata["warnings"].append(
+                        "cached-content resource expired or was unavailable; recreated once"
+                    )
+                    config["cached_content"] = cache_name
+                    response = await client.aio.models.generate_content(
+                        model=model,
+                        contents=contents,
+                        config=config if config else None,
+                    )
+                else:
+                    raise
+        finally:
+            await self._cleanup_cached_content(client, request, cache_metadata)
+        return self._parse_response(response, prompt_cache=cache_metadata)
+
+    async def _generate_stream_with_cache_lifecycle(
+        self,
+        client: Any,
+        model: str,
+        contents: Any,
+        config: dict[str, Any],
+        request: GenerateRequest,
+        cache_metadata: dict[str, Any] | None,
+    ) -> AsyncIterator[GenerateResponse]:
+        """Stream with cached-content expiry retry and cleanup."""
+        completed = False
+        yielded_chunk = False
+        try:
+            try:
+                async for chunk in self._generate_stream(client, model, contents, config):
+                    yielded_chunk = True
+                    yield chunk
+                completed = True
+            except Exception as exc:
+                prompt_cache = request.prompt_cache
+                if (
+                    not yielded_chunk
+                    and cache_metadata is not None
+                    and prompt_cache is not None
+                    and prompt_cache.create_if_missing
+                    and prompt_cache.source_text
+                    and _is_cached_content_expiry_error(exc)
+                ):
+                    cache_name = await self._create_cached_content(client, model, request)
+                    cache_metadata["cache_name"] = cache_name
+                    cache_metadata["created"] = True
+                    cache_metadata["recreated_after_expiry"] = True
+                    cache_metadata["warnings"].append(
+                        "cached-content resource expired or was unavailable; recreated once"
+                    )
+                    config["cached_content"] = cache_name
+                    async for chunk in self._generate_stream(client, model, contents, config):
+                        yielded_chunk = True
+                        yield chunk
+                    completed = True
+                else:
+                    raise
+        finally:
+            await self._cleanup_cached_content(client, request, cache_metadata)
+        if completed and cache_metadata is not None:
+            yield GenerateResponse(prompt_cache=cache_metadata)
 
     async def _generate_stream(
         self, client: Any, model: str, contents: Any, config: dict[str, Any]
@@ -342,7 +561,9 @@ class GeminiProvider(ProviderAdapter):
             if chunk.text:
                 yield GenerateResponse(text=chunk.text, content=chunk.text)
 
-    def _parse_response(self, response: Any) -> GenerateResponse:
+    def _parse_response(
+        self, response: Any, *, prompt_cache: dict[str, Any] | None = None
+    ) -> GenerateResponse:
         """Parse Gemini API response."""
         text = ""
         try:
@@ -364,6 +585,9 @@ class GeminiProvider(ProviderAdapter):
                 "completion_tokens": getattr(um, "candidates_token_count", 0) or 0,
                 "total_tokens": getattr(um, "total_token_count", 0) or 0,
             }
+            cache_read_tokens = _positive_int(getattr(um, "cached_content_token_count", 0))
+            if cache_read_tokens:
+                usage["cache_read_tokens"] = cache_read_tokens
 
         finish_reason = None
         if hasattr(response, "candidates") and response.candidates:
@@ -377,6 +601,7 @@ class GeminiProvider(ProviderAdapter):
             usage=usage,
             finish_reason=finish_reason,
             raw=response,
+            prompt_cache=prompt_cache,
         )
 
     def _model_supports_structured_output(self, model: str) -> bool:
@@ -407,9 +632,7 @@ class GeminiProvider(ProviderAdapter):
 
     async def supports(self, capability: str) -> bool:
         """Check if the provider supports a capability."""
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         """Perform a health check on the Gemini API."""

--- a/src/llm_council/providers/openai.py
+++ b/src/llm_council/providers/openai.py
@@ -404,6 +404,11 @@ class OpenAIProvider(ProviderAdapter):
                 "completion_tokens": completion_tokens,
                 "total_tokens": total_tokens,
             }
+            prompt_token_details = getattr(response.usage, "prompt_tokens_details", None)
+            cached_tokens = getattr(prompt_token_details, "cached_tokens", 0) or 0
+            if isinstance(cached_tokens, int) and not isinstance(cached_tokens, bool):
+                if cached_tokens > 0:
+                    usage["cache_read_tokens"] = cached_tokens
 
         return GenerateResponse(
             text=message.content,
@@ -476,9 +481,7 @@ class OpenAIProvider(ProviderAdapter):
 
     async def supports(self, capability: str) -> bool:
         """Check if the provider supports a capability."""
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         """Perform a health check on the OpenAI API."""

--- a/src/llm_council/providers/openrouter.py
+++ b/src/llm_council/providers/openrouter.py
@@ -33,6 +33,7 @@ FAST_MODEL = "anthropic/claude-haiku-4-5"
 REASONING_MODEL = "anthropic/claude-opus-4-6"
 CODE_MODEL = "openai/gpt-5.4"
 CRITIC_MODEL = "anthropic/claude-sonnet-4-6"
+OPENROUTER_CACHE_CONTROL_MODEL_PREFIXES = ("anthropic/",)
 logger = logging.getLogger(__name__)
 
 
@@ -97,6 +98,32 @@ def _prepare_structured_output_schema(
     if not _schema_is_strict_compatible(sanitized):
         return sanitized, False
     return sanitized, True
+
+
+def _supports_cache_control_model(model: str) -> bool:
+    """Return True when the OpenRouter route is known to support top-level cache_control."""
+
+    return model.startswith(OPENROUTER_CACHE_CONTROL_MODEL_PREFIXES)
+
+
+def _cache_control_for_request(request: GenerateRequest, model: str) -> dict[str, str] | None:
+    """Build OpenRouter top-level cache_control only for explicitly allowed routes."""
+
+    if request.prompt_cache is None or not request.prompt_cache.enabled:
+        return None
+    if not _supports_cache_control_model(model):
+        return None
+
+    cache_control = {"type": "ephemeral"}
+    if request.prompt_cache.ttl == "1h":
+        cache_control["ttl"] = "1h"
+    return cache_control
+
+
+def _positive_int(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
 
 
 class OpenRouterProvider(ProviderAdapter):
@@ -183,8 +210,9 @@ class OpenRouterProvider(ProviderAdapter):
 
     def _build_request_body(self, request: GenerateRequest) -> dict[str, Any]:
         """Convert GenerateRequest to OpenRouter API format."""
+        model = request.model or self._default_model
         body: dict[str, Any] = {
-            "model": request.model or self._default_model,
+            "model": model,
         }
 
         # Handle messages vs prompt
@@ -213,6 +241,10 @@ class OpenRouterProvider(ProviderAdapter):
             body["tools"] = list(request.tools)
         if request.tool_choice is not None:
             body["tool_choice"] = request.tool_choice
+
+        cache_control = _cache_control_for_request(request, model)
+        if cache_control is not None:
+            body["cache_control"] = cache_control
 
         # Handle structured output - transform to OpenRouter's format (OpenAI-compatible)
         # See: https://openrouter.ai/docs/guides/features/structured-outputs
@@ -364,6 +396,17 @@ class OpenRouterProvider(ProviderAdapter):
                 "completion_tokens": usage.get("completion_tokens", 0) or 0,
                 "total_tokens": usage.get("total_tokens", 0) or 0,
             }
+            prompt_token_details = usage.get("prompt_tokens_details")
+            cached_tokens = 0
+            if isinstance(prompt_token_details, dict):
+                cached_tokens = _positive_int(prompt_token_details.get("cached_tokens"))
+            else:
+                cached_tokens = _positive_int(getattr(prompt_token_details, "cached_tokens", 0))
+            cache_write_tokens = _positive_int(usage.get("cache_write_tokens"))
+            if cached_tokens:
+                usage_dict["cache_read_tokens"] = cached_tokens
+            if cache_write_tokens:
+                usage_dict["cache_creation_tokens"] = cache_write_tokens
 
         return GenerateResponse(
             text=content,
@@ -397,9 +440,7 @@ class OpenRouterProvider(ProviderAdapter):
         Returns:
             True if the capability is supported.
         """
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         """Perform a health check on the OpenRouter API.

--- a/src/llm_council/providers/vertex.py
+++ b/src/llm_council/providers/vertex.py
@@ -13,11 +13,12 @@ Supports both Application Default Credentials (ADC) and service account authenti
 from __future__ import annotations
 
 import contextlib
+import inspect
 import logging
 import os
 import time
 from collections.abc import AsyncIterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from llm_council.providers.anthropic import (
     STRUCTURED_OUTPUT_MODEL_PREFIXES as ANTHROPIC_STRUCTURED_OUTPUT_PREFIXES,
@@ -64,6 +65,55 @@ ENV_RETRY_ATTEMPTS = "VERTEX_AI_RETRY_ATTEMPTS"
 CLAUDE_MODEL_PREFIXES = ("claude-",)
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_vertex_model(model: str) -> str:
+    normalized = model.split("@", 1)[0]
+    if "/models/" in normalized:
+        normalized = normalized.rsplit("/models/", 1)[1]
+    return normalized
+
+
+def _positive_int(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
+
+
+def _cache_ttl_seconds(ttl: str) -> str:
+    return "3600s" if ttl == "1h" else "300s"
+
+
+def _cache_billing_warning() -> str:
+    return (
+        "Vertex Gemini cached-content resources can incur storage-duration billing until "
+        "TTL expiry or successful cleanup."
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _is_cached_content_expiry_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "cached" in message and (
+        "expired" in message or "not found" in message or "404" in message
+    )
+
+
+def _cache_control_for_request(request: GenerateRequest) -> dict[str, str] | None:
+    if request.prompt_cache is None or not request.prompt_cache.enabled:
+        return None
+    if request.prompt_cache.mode != "auto":
+        return None
+
+    cache_control = {"type": "ephemeral"}
+    if request.prompt_cache.ttl == "1h":
+        cache_control["ttl"] = "1h"
+    return cache_control
 
 
 class VertexAIProvider(ProviderAdapter):
@@ -181,7 +231,8 @@ class VertexAIProvider(ProviderAdapter):
 
     def _is_claude_model(self, model: str) -> bool:
         """Check if a model is a Claude model."""
-        return any(model.startswith(prefix) for prefix in CLAUDE_MODEL_PREFIXES)
+        normalized = _normalize_vertex_model(model)
+        return any(normalized.startswith(prefix) for prefix in CLAUDE_MODEL_PREFIXES)
 
     def _client_timeout_ms(self, request: GenerateRequest | None = None) -> int:
         """Resolve the SDK timeout for a request."""
@@ -230,6 +281,116 @@ class VertexAIProvider(ProviderAdapter):
         if self._gemini_client is None:
             self._gemini_client = self._build_gemini_client(timeout_ms=resolved_timeout)
         return self._gemini_client
+
+    def _cache_client(self, client: Any) -> Any:
+        aio_client = getattr(client, "aio", None)
+        caches = getattr(aio_client, "caches", None)
+        if caches is not None:
+            return caches
+        return client.caches
+
+    def _cache_create_config(self, request: GenerateRequest) -> dict[str, Any]:
+        prompt_cache = request.prompt_cache
+        if prompt_cache is None or prompt_cache.source_text is None:
+            raise ValueError("cached-content creation requires source_text.")
+
+        config: dict[str, Any] = {
+            "contents": prompt_cache.source_text,
+            "ttl": _cache_ttl_seconds(prompt_cache.ttl),
+        }
+        if prompt_cache.display_name:
+            config["display_name"] = prompt_cache.display_name
+        return config
+
+    async def _create_cached_content(
+        self, client: Any, model: str, request: GenerateRequest
+    ) -> str:
+        cache = await _maybe_await(
+            self._cache_client(client).create(
+                model=model,
+                config=self._cache_create_config(request),
+            )
+        )
+        cache_name = getattr(cache, "name", None)
+        if not cache_name:
+            raise ValueError("cached-content create response did not include a resource name.")
+        return cast(str, cache_name)
+
+    async def _refresh_cached_content_ttl(
+        self, client: Any, cache_name: str, request: GenerateRequest
+    ) -> None:
+        prompt_cache = request.prompt_cache
+        if prompt_cache is None:
+            return
+        await _maybe_await(
+            self._cache_client(client).update(
+                name=cache_name,
+                config={"ttl": _cache_ttl_seconds(prompt_cache.ttl)},
+            )
+        )
+
+    async def _delete_cached_content(self, client: Any, cache_name: str) -> None:
+        await _maybe_await(self._cache_client(client).delete(name=cache_name))
+
+    def _new_cache_metadata(self, cache_name: str | None) -> dict[str, Any]:
+        return {
+            "cache_name": cache_name,
+            "created": False,
+            "refreshed": False,
+            "deleted": None,
+            "recreated_after_expiry": False,
+            "warnings": [],
+            "billing_warning": _cache_billing_warning(),
+        }
+
+    async def _prepare_cached_content(
+        self,
+        client: Any,
+        model: str,
+        request: GenerateRequest,
+        config: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        prompt_cache = request.prompt_cache
+        if (
+            prompt_cache is None
+            or not prompt_cache.enabled
+            or prompt_cache.mode != "cached_content"
+        ):
+            return None
+
+        metadata = self._new_cache_metadata(prompt_cache.cached_content_name)
+        cache_name = prompt_cache.cached_content_name
+        if not cache_name and prompt_cache.create_if_missing:
+            cache_name = await self._create_cached_content(client, model, request)
+            metadata["cache_name"] = cache_name
+            metadata["created"] = True
+
+        if cache_name and prompt_cache.refresh_ttl:
+            try:
+                await self._refresh_cached_content_ttl(client, cache_name, request)
+                metadata["refreshed"] = True
+            except Exception as exc:
+                metadata["warnings"].append(f"ttl refresh failed: {exc}")
+
+        if cache_name:
+            config["cached_content"] = cache_name
+        return metadata
+
+    async def _cleanup_cached_content(
+        self, client: Any, request: GenerateRequest, metadata: dict[str, Any] | None
+    ) -> None:
+        prompt_cache = request.prompt_cache
+        if metadata is None or prompt_cache is None or not prompt_cache.delete_after:
+            return
+        cache_name = metadata.get("cache_name")
+        if not cache_name:
+            return
+        try:
+            await self._delete_cached_content(client, str(cache_name))
+            metadata["deleted"] = True
+        except Exception as exc:
+            metadata["deleted"] = False
+            metadata["warnings"].append(f"cleanup failed: {exc}")
 
     def _get_claude_client(self) -> Any:
         """Get or create the Claude Vertex AI client."""
@@ -317,6 +478,7 @@ class VertexAIProvider(ProviderAdapter):
             config["top_p"] = request.top_p
         if request.stop:
             config["stop_sequences"] = list(request.stop)
+        cache_metadata = await self._prepare_cached_content(client, model, request, config)
 
         # Handle structured output
         if request.structured_output:
@@ -352,14 +514,91 @@ class VertexAIProvider(ProviderAdapter):
                 }
 
         if request.stream:
-            return self._generate_stream(client, model, contents, config)
+            return self._generate_stream_with_cache_lifecycle(
+                client, model, contents, config, request, cache_metadata
+            )
 
-        response = await client.aio.models.generate_content(
-            model=model,
-            contents=contents,
-            config=config if config else None,
-        )
-        return self._parse_response(response)
+        try:
+            try:
+                response = await client.aio.models.generate_content(
+                    model=model,
+                    contents=contents,
+                    config=config if config else None,
+                )
+            except Exception as exc:
+                prompt_cache = request.prompt_cache
+                if (
+                    cache_metadata is not None
+                    and prompt_cache is not None
+                    and prompt_cache.create_if_missing
+                    and prompt_cache.source_text
+                    and _is_cached_content_expiry_error(exc)
+                ):
+                    cache_name = await self._create_cached_content(client, model, request)
+                    cache_metadata["cache_name"] = cache_name
+                    cache_metadata["created"] = True
+                    cache_metadata["recreated_after_expiry"] = True
+                    cache_metadata["warnings"].append(
+                        "cached-content resource expired or was unavailable; recreated once"
+                    )
+                    config["cached_content"] = cache_name
+                    response = await client.aio.models.generate_content(
+                        model=model,
+                        contents=contents,
+                        config=config if config else None,
+                    )
+                else:
+                    raise
+        finally:
+            await self._cleanup_cached_content(client, request, cache_metadata)
+        return self._parse_response(response, prompt_cache=cache_metadata)
+
+    async def _generate_stream_with_cache_lifecycle(
+        self,
+        client: Any,
+        model: str,
+        contents: Any,
+        config: dict[str, Any],
+        request: GenerateRequest,
+        cache_metadata: dict[str, Any] | None,
+    ) -> AsyncIterator[GenerateResponse]:
+        """Stream with cached-content expiry retry and cleanup."""
+        completed = False
+        yielded_chunk = False
+        try:
+            try:
+                async for chunk in self._generate_stream(client, model, contents, config):
+                    yielded_chunk = True
+                    yield chunk
+                completed = True
+            except Exception as exc:
+                prompt_cache = request.prompt_cache
+                if (
+                    not yielded_chunk
+                    and cache_metadata is not None
+                    and prompt_cache is not None
+                    and prompt_cache.create_if_missing
+                    and prompt_cache.source_text
+                    and _is_cached_content_expiry_error(exc)
+                ):
+                    cache_name = await self._create_cached_content(client, model, request)
+                    cache_metadata["cache_name"] = cache_name
+                    cache_metadata["created"] = True
+                    cache_metadata["recreated_after_expiry"] = True
+                    cache_metadata["warnings"].append(
+                        "cached-content resource expired or was unavailable; recreated once"
+                    )
+                    config["cached_content"] = cache_name
+                    async for chunk in self._generate_stream(client, model, contents, config):
+                        yielded_chunk = True
+                        yield chunk
+                    completed = True
+                else:
+                    raise
+        finally:
+            await self._cleanup_cached_content(client, request, cache_metadata)
+        if completed and cache_metadata is not None:
+            yield GenerateResponse(prompt_cache=cache_metadata)
 
     async def _generate_stream(
         self, client: Any, model: str, contents: Any, config: dict[str, Any]
@@ -374,7 +613,9 @@ class VertexAIProvider(ProviderAdapter):
             if chunk.text:
                 yield GenerateResponse(text=chunk.text, content=chunk.text)
 
-    def _parse_response(self, response: Any) -> GenerateResponse:
+    def _parse_response(
+        self, response: Any, *, prompt_cache: dict[str, Any] | None = None
+    ) -> GenerateResponse:
         """Parse Vertex AI response."""
         text = ""
         try:
@@ -395,6 +636,9 @@ class VertexAIProvider(ProviderAdapter):
                 "completion_tokens": getattr(um, "candidates_token_count", 0) or 0,
                 "total_tokens": getattr(um, "total_token_count", 0) or 0,
             }
+            cache_read_tokens = _positive_int(getattr(um, "cached_content_token_count", 0))
+            if cache_read_tokens:
+                usage["cache_read_tokens"] = cache_read_tokens
 
         finish_reason = None
         if hasattr(response, "candidates") and response.candidates:
@@ -408,6 +652,7 @@ class VertexAIProvider(ProviderAdapter):
             usage=usage,
             finish_reason=finish_reason,
             raw=response,
+            prompt_cache=prompt_cache,
         )
 
     async def _generate_claude(
@@ -444,6 +689,9 @@ class VertexAIProvider(ProviderAdapter):
             kwargs["stop_sequences"] = list(request.stop)
         if request.tools:
             kwargs["tools"] = list(request.tools)
+        cache_control = _cache_control_for_request(request)
+        if cache_control is not None:
+            kwargs["extra_body"] = {"cache_control": cache_control}
 
         # Handle structured output for Claude 4.x models
         use_beta = False
@@ -522,12 +770,19 @@ class VertexAIProvider(ProviderAdapter):
         usage = None
         if hasattr(response, "usage") and response.usage:
             input_tokens = response.usage.input_tokens or 0
+            cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
             output_tokens = response.usage.output_tokens or 0
+            prompt_tokens = input_tokens + cache_read_tokens + cache_creation_tokens
             usage = {
-                "prompt_tokens": input_tokens,
+                "prompt_tokens": prompt_tokens,
                 "completion_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
+                "total_tokens": prompt_tokens + output_tokens,
             }
+            if cache_read_tokens:
+                usage["cache_read_tokens"] = cache_read_tokens
+            if cache_creation_tokens:
+                usage["cache_creation_tokens"] = cache_creation_tokens
 
         return GenerateResponse(
             text=text,
@@ -557,9 +812,7 @@ class VertexAIProvider(ProviderAdapter):
 
     async def supports(self, capability: str) -> bool:
         """Check if the provider supports a capability."""
-        if not self.supports_capability_name(capability):
-            return False
-        return getattr(self.capabilities, capability, False)
+        return self.supports_capability(capability)
 
     async def doctor(self) -> DoctorResult:
         """Perform a health check on Vertex AI.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,661 @@
+# Cross-Provider Prompt Caching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the proven Anthropic prompt-caching proof slice into a conservative cross-provider prompt-caching feature with provider-specific semantics, deterministic tests, live telemetry proof, and council review gates.
+
+**Architecture:** Keep the public request surface additive and provider-neutral, but keep wire-format behavior adapter-owned. The compiler decides whether a provider can keep, drop, or transform `prompt_cache`; each adapter performs final request serialization and usage parsing. Do not pretend all providers support the same caching model.
+
+**Tech Stack:** Python, Pydantic v2, pytest, pytest-asyncio, Anthropic SDK, OpenAI SDK, Google GenAI SDK, HTTPX/OpenRouter direct API, existing `council` reviewer.
+
+---
+
+## Current State
+
+- [x] Branch is based on `origin/main` at `24e23b8`.
+- [x] Anthropic proof slice implemented locally.
+- [x] Anthropic proof slice locally verified with `PYTHONPATH=src uv run pytest tests/test_request_compiler.py tests/test_providers.py -q`.
+- [x] Current local result: `114 passed`.
+- [x] Anthropic live proof succeeded with identical large prompt:
+  - first response: `cache_creation_input_tokens=10988`
+  - second response: `cache_read_input_tokens=10988`
+- [x] Council final focused review approved the Anthropic proof slice with no blocking issues.
+- [x] Design spec exists at `docs/providers/2026-06-09-anthropic-prompt-caching-design.md`.
+
+## Implementation Status Update
+
+- [x] Shared `PromptCacheConfig` supports Anthropic-style `auto` and Gemini-style `cached_content` passthrough.
+- [x] Compiler keeps or drops `prompt_cache` by provider, route, model family, and cache mode with explicit decisions.
+- [x] Anthropic baseline is hardened for direct, beta, stream, write, and cache-hit-only paths.
+- [x] OpenAI telemetry-only parsing is implemented without request mutation.
+- [x] OpenRouter route-gated passthrough is implemented for `anthropic/` routes only.
+- [x] Gemini cached-content lifecycle is implemented for create, TTL refresh, expiry recreation, and best-effort cleanup.
+- [x] Vertex split paths are implemented: Claude uses Anthropic-style controls, Gemini uses cached-content lifecycle APIs.
+- [x] Execution metadata records normalized cache usage without changing cost token totals.
+- [x] Provider support matrix is documented at `docs/providers/2026-06-09-cross-provider-prompt-caching.md`.
+- [x] Full local suite passed after the final documentation updates: `418 passed`.
+- [x] Final council follow-up review approved with comments and no blocking issues.
+- [x] OpenRouter live proof succeeded on `anthropic/claude-haiku-4.5`: second identical call returned `cache_read_tokens=8116`.
+- [x] Gemini API live proof succeeded on `gemini-3.1-pro-preview`: cache created, `cache_read_tokens=12603`, cleanup deleted the resource.
+- [x] Vertex Gemini live proof succeeded on `gemini-3.1-pro-preview`: cache created, `cache_read_tokens=14002`, cleanup deleted the resource.
+- [ ] Vertex Claude still needs separate live proof for the Anthropic Vertex SDK path.
+
+## Non-Negotiable Design Rules
+
+- [ ] Provider-specific request serialization stays inside adapters.
+- [ ] Compiler emits decisions; it does not build provider wire payloads.
+- [ ] Unsupported providers drop `prompt_cache` with an explicit compilation decision.
+- [ ] Tests assert request shape and usage telemetry, not latency or cost.
+- [ ] Live tests are opt-in and skipped by default.
+- [ ] OpenRouter is route/model gated; it is not advertised as a stable universal cache provider.
+- [ ] Gemini cached content is treated as object lifecycle work, not as the same feature as Anthropic `cache_control`.
+- [ ] Vertex is split into Claude and Gemini paths.
+
+## Provider Assessment Matrix
+
+| Provider | First supported scope | Request behavior | Usage telemetry | Risk | Go/No-Go rule |
+| --- | --- | --- | --- | --- | --- |
+| Anthropic | Implemented proof slice | `extra_body={"cache_control": ...}` for locked SDK | `cache_read_input_tokens`, `cache_creation_input_tokens`, `cache_creation` buckets | SDK field drift | Keep as baseline; re-check when upgrading Anthropic SDK |
+| OpenAI | Telemetry-only | No request mutation; prompt caching is automatic | `usage.prompt_tokens_details.cached_tokens` | False expectation of control | Ship only usage parsing and docs |
+| OpenRouter | Route-gated passthrough | Only for explicitly cache-capable model routes; pass `cache_control` through body | `prompt_tokens_details.cached_tokens`, `cache_write_tokens` when present | Routed provider variability | Ship disabled by default unless route guard passes |
+| Gemini | Cached content object lifecycle | Create/reuse/delete `cachedContents`; pass cached content name in config | `usage_metadata` cache token fields when present | Lifecycle/storage billing | Ship after object lifecycle tests exist |
+| Vertex Claude | Anthropic-like path | Use Anthropic Vertex SDK path if `extra_body` or equivalent is accepted | Anthropic-style usage if returned | SDK parity uncertainty | Ship after live Vertex Claude proof |
+| Vertex Gemini | Gemini-like path | Use Google GenAI Vertex cached content APIs | Gemini-style usage metadata | IAM/region/resource complexity | Ship after direct Gemini lifecycle is stable |
+| CLI providers | Telemetry-only | No request mutation in this plan | Preserve existing cached-input parsing | CLI output drift | Do not expand request surface in this phase |
+
+---
+
+## Phase 1: Stabilize Shared Cache Contract
+
+**Files:**
+- Modify: `src/llm_council/providers/base.py`
+- Modify: `src/llm_council/providers/compiler.py`
+- Test: `tests/test_providers.py`
+- Test: `tests/test_request_compiler.py`
+
+- [ ] **Step 1: Lock public cache config semantics**
+
+Keep `PromptCacheConfig` intentionally narrow until more providers are implemented:
+
+```python
+class PromptCacheConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enabled: bool = Field(default=True)
+    mode: Literal["auto"] = Field(default="auto")
+    ttl: Literal["5m", "1h"] = Field(default="5m")
+```
+
+Do not add `breakpoints`, `provider_options`, or `cached_content_name` until the provider slice that needs them begins.
+
+- [ ] **Step 2: Test conservative capability semantics**
+
+Add or retain tests proving:
+
+```python
+assert ProviderCapabilities().prompt_caching == "none"
+assert OpenAIProvider(api_key="test").supports("prompt_caching") is False
+assert AnthropicProvider(api_key="test").supports("prompt_caching") is True
+```
+
+Expected: non-Anthropic providers do not become truthy just because `prompt_caching` is a string field.
+
+- [ ] **Step 3: Test compiler decision matrix**
+
+Add table-driven tests:
+
+```python
+cases = [
+    ("anthropic", "claude-opus-4-6", "supported"),
+    ("openai", "gpt-5.4", "dropped"),
+    ("openrouter", "anthropic/claude-opus-4-6", "dropped"),
+    ("gemini", "gemini-3.1-pro-preview", "dropped"),
+    ("vertex-ai", "gemini-3.1-pro-preview", "dropped"),
+]
+```
+
+Expected:
+
+- Anthropic keeps `prompt_cache`.
+- All others drop it until their provider slice is implemented.
+- Every drop emits a `CompilationDecision(option="prompt_cache", action="dropped", ...)`.
+
+- [ ] **Step 4: Run shared-contract tests**
+
+Run:
+
+```bash
+PYTHONPATH=src uv run pytest tests/test_request_compiler.py tests/test_providers.py -q
+```
+
+Expected: pass.
+
+---
+
+## Phase 2: Anthropic Baseline Hardening
+
+**Files:**
+- Modify: `src/llm_council/providers/anthropic.py`
+- Modify: `tests/test_providers.py`
+- Modify: `docs/providers/2026-06-09-anthropic-prompt-caching-design.md`
+
+- [ ] **Step 1: Preserve SDK 0.75.0 request-shape workaround**
+
+Keep `cache_control` inside `extra_body`:
+
+```python
+kwargs["extra_body"] = {"cache_control": cache_control}
+```
+
+Reason: locked `anthropic==0.75.0` rejects `cache_control` as a direct `messages.create()` keyword.
+
+- [ ] **Step 2: Add beta-path cache propagation test**
+
+Add a test combining `prompt_cache` with structured output or reasoning so `client.beta.messages.create(...)` receives:
+
+```python
+extra_body={"cache_control": {"type": "ephemeral"}}
+```
+
+Expected: no regression when existing beta paths are combined with prompt caching.
+
+- [ ] **Step 3: Add streaming path cache propagation test**
+
+Add a stream-path test that verifies `_generate_stream()` receives kwargs containing:
+
+```python
+{"extra_body": {"cache_control": {"type": "ephemeral"}}}
+```
+
+Expected: streaming and non-streaming request shaping stay consistent.
+
+- [ ] **Step 4: Add hit and write usage tests**
+
+Keep current cache write test and add cache-hit-only test:
+
+```python
+usage=SimpleNamespace(
+    input_tokens=3,
+    cache_read_input_tokens=10988,
+    cache_creation_input_tokens=0,
+    output_tokens=16,
+)
+```
+
+Expected parsed usage:
+
+```python
+{
+    "prompt_tokens": 10991,
+    "completion_tokens": 16,
+    "total_tokens": 11007,
+    "cache_read_tokens": 10988,
+}
+```
+
+- [ ] **Step 5: Run Anthropic local tests**
+
+Run:
+
+```bash
+PYTHONPATH=src uv run pytest tests/test_providers.py::TestAnthropicPromptCaching -q
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Run optional Anthropic live proof**
+
+Guard with `ANTHROPIC_API_KEY`.
+
+Test shape:
+
+- Same model.
+- Same system prompt.
+- Same user prompt.
+- Large stable prefix above cache threshold.
+- Two identical calls within 5 minutes.
+
+Expected:
+
+- First call returns `cache_creation_input_tokens > 0`.
+- Second call returns `cache_read_input_tokens > 0`.
+- Do not assert latency.
+
+---
+
+## Phase 3: OpenAI Telemetry-Only Support
+
+**Files:**
+- Modify: `src/llm_council/providers/openai.py`
+- Modify: `tests/test_providers.py`
+- Modify: `docs/providers/creating-providers.md` or provider support docs
+
+- [ ] **Step 1: Do not send request cache controls**
+
+OpenAI prompt caching is automatic. Do not add any request field to OpenAI SDK kwargs for `prompt_cache`.
+
+- [ ] **Step 2: Parse cached-token telemetry**
+
+In `_parse_response()`, inspect:
+
+```python
+response.usage.prompt_tokens_details.cached_tokens
+```
+
+Add normalized field when nonzero:
+
+```python
+usage["cache_read_tokens"] = cached_tokens
+```
+
+Use `cache_read_tokens` rather than `cache_creation_tokens` because OpenAI reports cached prompt tokens, not explicit writes.
+
+- [ ] **Step 3: Happy-path test**
+
+Mock OpenAI usage:
+
+```python
+usage = SimpleNamespace(
+    prompt_tokens=2000,
+    completion_tokens=100,
+    total_tokens=2100,
+    prompt_tokens_details=SimpleNamespace(cached_tokens=1200),
+)
+```
+
+Expected:
+
+```python
+usage["cache_read_tokens"] == 1200
+```
+
+- [ ] **Step 4: Unhappy-path tests**
+
+Cover:
+
+- `prompt_tokens_details` missing.
+- `cached_tokens` missing.
+- `cached_tokens=0`.
+- `prompt_cache` requested and compiler drops it for OpenAI.
+
+Expected: parsing remains backward-compatible and no SDK kwargs include cache controls.
+
+- [ ] **Step 5: Run OpenAI tests**
+
+Run:
+
+```bash
+PYTHONPATH=src uv run pytest tests/test_providers.py::TestOpenAIProviderRequestParams tests/test_request_compiler.py -q
+```
+
+Expected: pass.
+
+---
+
+## Phase 4: OpenRouter Route-Gated Passthrough
+
+**Files:**
+- Modify: `src/llm_council/providers/openrouter.py`
+- Modify: `src/llm_council/providers/compiler.py`
+- Modify: `tests/test_providers.py`
+- Modify: `tests/test_request_compiler.py`
+- Modify: `docs/quickstart/openrouter.md`
+
+- [ ] **Step 1: Define route guard**
+
+Only keep `prompt_cache` for OpenRouter when the model route is explicitly cache-capable.
+
+Initial allowlist:
+
+```python
+OPENROUTER_CACHE_CONTROL_MODEL_PREFIXES = (
+    "anthropic/",
+)
+```
+
+This is intentionally narrow.
+
+- [ ] **Step 2: Compiler behavior**
+
+For OpenRouter:
+
+- Keep `prompt_cache` only when model starts with an allowed prefix.
+- Drop otherwise with decision detail:
+
+```text
+OpenRouter prompt caching is route-dependent; model is not in cache-control allowlist
+```
+
+- [ ] **Step 3: Request serialization**
+
+In `_build_request_body()`, when allowed:
+
+```python
+body["cache_control"] = {"type": "ephemeral"}
+```
+
+For `ttl="1h"`:
+
+```python
+body["cache_control"] = {"type": "ephemeral", "ttl": "1h"}
+```
+
+- [ ] **Step 4: Parse telemetry**
+
+Parse:
+
+```python
+usage.prompt_tokens_details.cached_tokens
+usage.cache_write_tokens
+```
+
+Normalize:
+
+```python
+usage["cache_read_tokens"] = cached_tokens
+usage["cache_creation_tokens"] = cache_write_tokens
+```
+
+- [ ] **Step 5: Happy-path tests**
+
+Cover:
+
+- `anthropic/claude-opus-4-6` keeps cache config.
+- request body includes `cache_control`.
+- response parsing includes read/write cache tokens.
+
+- [ ] **Step 6: Unhappy-path tests**
+
+Cover:
+
+- `openai/gpt-5.4` route drops cache config.
+- no `cache_control` emitted after compiler drop.
+- malformed `prompt_tokens_details` does not crash.
+- missing usage does not crash.
+- virtual provider name like `anthropic/claude-opus-4-6` resolves through OpenRouter path.
+
+- [ ] **Step 7: Run OpenRouter tests**
+
+Run:
+
+```bash
+PYTHONPATH=src uv run pytest tests/test_request_compiler.py tests/test_providers.py::TestOpenRouterProviderEnvModel -q
+```
+
+Expected: pass.
+
+---
+
+## Phase 5: Gemini Cached Content Lifecycle
+
+**Files:**
+- Modify: `src/llm_council/providers/base.py`
+- Modify: `src/llm_council/providers/gemini.py`
+- Modify: `tests/test_providers.py`
+- Create if needed: `tests/test_gemini_prompt_cache.py`
+- Modify: provider docs
+
+- [ ] **Step 1: Extend cache config only when Gemini work begins**
+
+Add cached content fields:
+
+```python
+class PromptCacheConfig(BaseModel):
+    enabled: bool = True
+    mode: Literal["auto", "cached_content"] = "auto"
+    ttl: Literal["5m", "1h"] = "5m"
+    cached_content_name: str | None = None
+```
+
+Do not add this before the Gemini slice begins.
+
+- [ ] **Step 2: Decide lifecycle ownership**
+
+Use a conservative first pass:
+
+- `cached_content_name` passthrough only.
+- Do not auto-create/delete cached contents in `generate()` yet.
+
+Reason: auto lifecycle introduces storage billing, cleanup, and concurrent reuse concerns.
+
+- [ ] **Step 3: Request serialization**
+
+When `cached_content_name` is provided:
+
+```python
+config["cached_content"] = request.prompt_cache.cached_content_name
+```
+
+Use the exact Google GenAI SDK field name verified against current installed `google-genai`.
+
+- [ ] **Step 4: Parse telemetry**
+
+Inspect `response.usage_metadata` for cache token fields available in current SDK.
+
+Expected normalized fields:
+
+```python
+usage["cache_read_tokens"] = cached_token_count
+```
+
+Use raw fallback only when field names differ.
+
+- [ ] **Step 5: Happy-path tests**
+
+Mock `client.aio.models.generate_content()` and assert:
+
+- `config.cached_content` or dict equivalent is present.
+- regular generation config fields still pass.
+- cache usage telemetry is parsed when present.
+
+- [ ] **Step 6: Unhappy-path tests**
+
+Cover:
+
+- `mode="cached_content"` without `cached_content_name` raises validation error or compiler drop.
+- invalid cached content name shape is rejected if SDK requires a resource path.
+- missing `usage_metadata` does not crash.
+- existing non-cache Gemini requests unchanged.
+
+- [ ] **Step 7: Deferred lifecycle tests**
+
+Before auto-create/delete support, write design notes for:
+
+- create cached content
+- reuse cached content
+- TTL expiration
+- delete cleanup
+- IAM/API failures
+- storage billing warnings
+
+Do not implement lifecycle until this design is approved.
+
+---
+
+## Phase 6: Vertex Split Paths
+
+**Files:**
+- Modify: `src/llm_council/providers/vertex.py`
+- Modify: `tests/test_providers.py`
+- Modify: `tests/test_request_compiler.py`
+- Modify: Vertex provider docs
+
+- [ ] **Step 1: Vertex Claude path**
+
+Mirror Anthropic only after verifying `AsyncAnthropicVertex` accepts:
+
+```python
+extra_body={"cache_control": {"type": "ephemeral"}}
+```
+
+Happy path:
+
+- Claude Vertex model keeps `prompt_cache`.
+- request kwargs include `extra_body.cache_control`.
+- usage parser extracts Anthropic-style cache fields.
+
+Unhappy path:
+
+- Vertex Claude SDK rejects `extra_body`.
+- missing project/region still returns normal doctor errors.
+- prompt cache does not mask auth/model errors.
+
+- [ ] **Step 2: Vertex Gemini path**
+
+Mirror Gemini cached content passthrough only after direct Gemini slice is green.
+
+Happy path:
+
+- `cached_content_name` is passed to Google GenAI Vertex client config.
+- usage metadata parsed.
+
+Unhappy path:
+
+- Gemini Vertex model without cached content support drops config.
+- invalid resource/project/region does not get swallowed.
+- non-cache Vertex Gemini requests unchanged.
+
+- [ ] **Step 3: Compiler split**
+
+For `vertex-ai`:
+
+- Claude model: Anthropic-like behavior only if Vertex Claude support is verified.
+- Gemini model: Gemini-like behavior only if cached-content passthrough is implemented.
+- Unknown model: drop prompt cache.
+
+---
+
+## Phase 7: Cross-Provider Reporting
+
+**Files:**
+- Modify: `src/llm_council/engine/orchestrator.py`
+- Modify: tests around execution metadata if present
+- Modify: docs
+
+- [ ] **Step 1: Preserve current token accounting**
+
+Do not change existing `prompt_tokens`, `completion_tokens`, and `total_tokens` semantics without a separate compatibility decision.
+
+- [ ] **Step 2: Add optional cache summary metadata**
+
+When provider usage includes cache keys, execution metadata can aggregate:
+
+```python
+cache_read_tokens
+cache_creation_tokens
+cache_creation_5m_tokens
+cache_creation_1h_tokens
+```
+
+- [ ] **Step 3: Happy-path tests**
+
+Create provider fake results with cache usage and assert summary fields are present.
+
+- [ ] **Step 4: Unhappy-path tests**
+
+Cover:
+
+- usage is `None`.
+- cache usage fields absent.
+- cache usage fields zero.
+- provider returns unexpected non-int values.
+
+Expected: no crash; raw provider response remains available for diagnostics.
+
+---
+
+## Phase 8: Full Test Matrix
+
+Run after each provider slice:
+
+```bash
+PYTHONPATH=src uv run pytest tests/test_request_compiler.py tests/test_providers.py -q
+```
+
+Run before council review:
+
+```bash
+PYTHONPATH=src uv run pytest -q
+```
+
+Live tests are opt-in only:
+
+```bash
+ANTHROPIC_API_KEY=... PYTHONPATH=src uv run --extra anthropic pytest tests/integration/test_prompt_cache_anthropic.py -q
+OPENAI_API_KEY=... PYTHONPATH=src uv run --extra openai pytest tests/integration/test_prompt_cache_openai.py -q
+OPENROUTER_API_KEY=... PYTHONPATH=src uv run pytest tests/integration/test_prompt_cache_openrouter.py -q
+GOOGLE_API_KEY=... PYTHONPATH=src uv run --extra gemini pytest tests/integration/test_prompt_cache_gemini.py -q
+GOOGLE_CLOUD_PROJECT=... PYTHONPATH=src uv run --extra vertex pytest tests/integration/test_prompt_cache_vertex.py -q
+```
+
+Live-test assertions:
+
+- assert telemetry fields, not latency
+- use large stable prefixes
+- run duplicate requests only where provider caching requires it
+- skip when credentials are absent
+- do not fail CI by default
+
+---
+
+## Phase 9: Council Review Gates
+
+- [x] **After Anthropic hardening**
+
+Run:
+
+```bash
+council run reviewer --runtime-profile bounded --reasoning-profile light --files src/llm_council/providers/base.py --files src/llm_council/providers/compiler.py --files src/llm_council/providers/anthropic.py --files tests/test_providers.py --files tests/test_request_compiler.py "Review Anthropic prompt-cache baseline hardening and local/live proof."
+```
+
+- [x] **After each provider slice**
+
+Run focused council review with:
+
+- changed provider file
+- shared model/compiler files
+- tests
+- local test result
+- live telemetry proof if available
+
+- [x] **Before full rollout**
+
+Run broad council review:
+
+```bash
+council run planner --mode assess "Assess cross-provider prompt-caching feature readiness, provider support matrix, implementation risks, and test evidence."
+```
+
+Go criteria:
+
+- no blocking council issues
+- local tests green
+- at least Anthropic live proof retained
+- OpenRouter/Gemini/Vertex live proofs either green or explicitly deferred
+
+---
+
+## Known Unhappy Paths To Preserve
+
+- [x] Unsupported provider receives `prompt_cache`: compiler drops with decision.
+- [x] Unsupported model route receives `prompt_cache`: compiler drops with decision.
+- [x] SDK rejects cache field: test fails locally before merge.
+- [x] Cache telemetry missing: parser returns normal usage without cache keys.
+- [x] Cache telemetry zero: parser omits optional cache keys or returns zero consistently.
+- [x] Provider auth failure: cache logic does not hide auth error.
+- [x] Provider model unavailable: cache logic does not hide model error.
+- [x] Live cache read not observed: do not infer from latency; report telemetry absence.
+- [ ] Gemini cached content expires: lifecycle layer must create a fresh object or return actionable error.
+- [ ] Gemini cached content delete fails: do not hide generation result; surface cleanup warning in lifecycle metadata.
+- [x] Vertex project/region mismatch: preserve existing doctor/error behavior.
+
+## Completion Criteria
+
+- [x] Provider support matrix is documented.
+- [x] Each provider slice has request-shape tests.
+- [x] Each provider slice has usage parsing tests.
+- [x] Each provider slice has unsupported-provider/model tests.
+- [x] Live proof exists for Anthropic and any provider marked fully supported.
+- [x] Full local test suite passes.
+- [x] Council final review approves.
+- [x] Follow-up docs explain which providers are supported, implicit, passthrough, deferred, or telemetry-only.

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -227,6 +227,97 @@ class TestCostEstimate:
         assert estimate.estimated_cost_usd == 0.0
 
 
+class TestCacheUsageReporting:
+    """Tests for normalized cache usage in execution metadata."""
+
+    def test_record_usage_adds_cache_summary_without_changing_token_totals(self):
+        orchestrator = Orchestrator(
+            providers=[],
+            config=OrchestratorConfig(enable_artifacts=False, enable_graceful_degradation=False),
+        )
+        orchestrator._execution_plan = {}
+
+        orchestrator._record_usage(
+            "anthropic",
+            {
+                "prompt_tokens": 130,
+                "completion_tokens": 5,
+                "total_tokens": 135,
+                "cache_read_tokens": 100,
+                "cache_creation_tokens": 20,
+                "cache_creation_5m_tokens": 12,
+            },
+        )
+
+        assert orchestrator._input_tokens["anthropic"] == 130
+        assert orchestrator._output_tokens["anthropic"] == 5
+        assert orchestrator._execution_plan["cache_usage"]["anthropic"] == {
+            "cache_read_tokens": 100,
+            "cache_creation_tokens": 20,
+            "cache_creation_5m_tokens": 12,
+        }
+
+    def test_record_usage_ignores_missing_zero_and_non_int_cache_values(self):
+        orchestrator = Orchestrator(
+            providers=[],
+            config=OrchestratorConfig(enable_artifacts=False, enable_graceful_degradation=False),
+        )
+        orchestrator._execution_plan = {}
+
+        orchestrator._record_usage(
+            "openai",
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 12,
+                "cache_read_tokens": 0,
+                "cache_creation_tokens": "bad",
+            },
+        )
+
+        assert "cache_usage" not in orchestrator._execution_plan
+
+    def test_prompt_cache_observation_distinguishes_requested_forwarded_and_observed(self):
+        orchestrator = Orchestrator(
+            providers=[],
+            config=OrchestratorConfig(enable_artifacts=False, enable_graceful_degradation=False),
+        )
+        orchestrator._execution_plan = {}
+
+        orchestrator._record_prompt_cache_observation(
+            phase="draft",
+            provider_name="openrouter",
+            requested=True,
+            forwarded=False,
+            usage=None,
+        )
+        orchestrator._record_prompt_cache_observation(
+            phase="draft",
+            provider_name="anthropic",
+            requested=True,
+            forwarded=True,
+            usage={"cache_read_tokens": 100},
+        )
+
+        assert orchestrator._execution_plan["prompt_cache_observations"]["draft"] == [
+            {
+                "provider": "openrouter",
+                "requested": True,
+                "forwarded": False,
+                "metrics_available": False,
+                "observed": False,
+            },
+            {
+                "provider": "anthropic",
+                "requested": True,
+                "forwarded": True,
+                "metrics_available": True,
+                "observed": True,
+                "usage": {"cache_read_tokens": 100},
+            },
+        ]
+
+
 class TestCouncilResult:
     """Tests for CouncilResult model."""
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -25,6 +25,7 @@ from llm_council.providers.base import (
     GenerateRequest,
     GenerateResponse,
     Message,
+    PromptCacheConfig,
     ProviderCapabilities,
     ReasoningConfig,
     StructuredOutputConfig,
@@ -66,6 +67,7 @@ class TestProviderCapabilities:
         assert caps.structured_output is False
         assert caps.multimodal is False
         assert caps.max_tokens is None
+        assert caps.prompt_caching == "none"
 
     def test_custom_capabilities(self):
         """Test custom capability values."""
@@ -75,12 +77,14 @@ class TestProviderCapabilities:
             structured_output=True,
             multimodal=True,
             max_tokens=8192,
+            prompt_caching="explicit",
         )
         assert caps.streaming is True
         assert caps.tool_use is True
         assert caps.structured_output is True
         assert caps.multimodal is True
         assert caps.max_tokens == 8192
+        assert caps.prompt_caching == "explicit"
 
 
 class TestMessage:
@@ -145,6 +149,69 @@ class TestGenerateRequest:
         assert req.top_p == 0.9
         assert req.stop == ["END"]
         assert req.stream is True
+
+    def test_request_accepts_prompt_cache_config(self):
+        """Test request with automatic prompt-cache config."""
+        req = GenerateRequest(
+            prompt="Hello",
+            prompt_cache=PromptCacheConfig(ttl="1h"),
+        )
+
+        assert req.prompt_cache is not None
+        assert req.prompt_cache.enabled is True
+        assert req.prompt_cache.mode == "auto"
+        assert req.prompt_cache.ttl == "1h"
+
+    def test_prompt_cache_rejects_unsupported_ttl(self):
+        """Only known provider-safe TTL labels should be accepted."""
+        with pytest.raises(ValueError):
+            PromptCacheConfig(ttl="24h")
+
+    def test_request_accepts_cached_content_prompt_cache_config(self):
+        """Gemini-style cached-content passthrough should be explicit."""
+        req = GenerateRequest(
+            prompt="Hello",
+            prompt_cache=PromptCacheConfig(
+                mode="cached_content",
+                cached_content_name="cachedContents/example",
+            ),
+        )
+
+        assert req.prompt_cache is not None
+        assert req.prompt_cache.mode == "cached_content"
+        assert req.prompt_cache.cached_content_name == "cachedContents/example"
+
+    def test_cached_content_mode_requires_cache_resource_name(self):
+        """Cached-content mode should not be valid without a cache resource name."""
+        with pytest.raises(ValueError):
+            PromptCacheConfig(mode="cached_content")
+
+    def test_cached_content_mode_rejects_non_resource_names(self):
+        """Cached-content mode should use provider cache resource names."""
+        with pytest.raises(ValueError):
+            PromptCacheConfig(mode="cached_content", cached_content_name="local-cache")
+
+    def test_cached_content_lifecycle_create_requires_source_text(self):
+        """Creating a cache resource should require explicit stable source text."""
+        with pytest.raises(ValueError):
+            PromptCacheConfig(mode="cached_content", create_if_missing=True)
+
+    def test_cached_content_lifecycle_accepts_create_refresh_and_cleanup(self):
+        """Lifecycle controls should be explicit on cached-content mode."""
+        config = PromptCacheConfig(
+            mode="cached_content",
+            create_if_missing=True,
+            refresh_ttl=True,
+            delete_after=True,
+            source_text="stable context",
+            display_name="test cache",
+            ttl="5m",
+        )
+
+        assert config.create_if_missing is True
+        assert config.refresh_ttl is True
+        assert config.delete_after is True
+        assert config.source_text == "stable context"
 
 
 class TestGenerateResponse:
@@ -420,6 +487,203 @@ class TestAnthropicThinkingType:
         assert "budget_tokens" not in call_kwargs["thinking"]
 
 
+class TestAnthropicPromptCaching:
+    """Tests for Anthropic automatic prompt caching."""
+
+    @pytest.mark.asyncio
+    async def test_generate_sends_default_cache_control_through_extra_body(self):
+        provider = AnthropicProvider(api_key="test-key")
+        client = AsyncMock()
+        provider._client = client
+
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.messages.create = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                messages=[Message(role="user", content="test")],
+                model="claude-opus-4-6",
+                prompt_cache=PromptCacheConfig(),
+            )
+        )
+
+        call_kwargs = client.messages.create.await_args_list[0].kwargs
+        assert call_kwargs["extra_body"]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_generate_sends_one_hour_cache_control_through_extra_body(self):
+        provider = AnthropicProvider(api_key="test-key")
+        client = AsyncMock()
+        provider._client = client
+
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.messages.create = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                messages=[Message(role="user", content="test")],
+                model="claude-opus-4-6",
+                prompt_cache=PromptCacheConfig(ttl="1h"),
+            )
+        )
+
+        call_kwargs = client.messages.create.await_args_list[0].kwargs
+        assert call_kwargs["extra_body"]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+        assert "cache_control" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_generate_without_prompt_cache_omits_cache_control(self):
+        provider = AnthropicProvider(api_key="test-key")
+        client = AsyncMock()
+        provider._client = client
+
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.messages.create = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                messages=[Message(role="user", content="test")],
+                model="claude-opus-4-6",
+            )
+        )
+
+        call_kwargs = client.messages.create.await_args_list[0].kwargs
+        assert "cache_control" not in call_kwargs
+        assert "extra_body" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_generate_beta_path_preserves_cache_control(self):
+        """Structured-output beta calls should still receive prompt-cache controls."""
+        provider = AnthropicProvider(api_key="test-key")
+        client = AsyncMock()
+        provider._client = client
+
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text='{"ok":true}')],
+            model="claude-opus-4-6",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.beta.messages.create = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                messages=[Message(role="user", content="test")],
+                model="claude-opus-4-6",
+                structured_output=StructuredOutputConfig(
+                    json_schema={
+                        "type": "object",
+                        "properties": {"ok": {"type": "boolean"}},
+                        "required": ["ok"],
+                        "additionalProperties": False,
+                    }
+                ),
+                prompt_cache=PromptCacheConfig(),
+            )
+        )
+
+        call_kwargs = client.beta.messages.create.await_args_list[0].kwargs
+        assert call_kwargs["extra_body"]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_generate_stream_path_preserves_cache_control(self):
+        """Streaming calls should receive the same prompt-cache request shape."""
+        provider = AnthropicProvider(api_key="test-key")
+        client = AsyncMock()
+        provider._client = client
+
+        async def stream_iter():
+            if False:
+                yield GenerateResponse(text="unused")
+
+        expected_stream = stream_iter()
+
+        with patch.object(provider, "_generate_stream", return_value=expected_stream) as stream:
+            result = await provider.generate(
+                GenerateRequest(
+                    messages=[Message(role="user", content="test")],
+                    model="claude-opus-4-6",
+                    stream=True,
+                    prompt_cache=PromptCacheConfig(),
+                )
+            )
+
+        assert result is expected_stream
+        call_kwargs = stream.call_args.args[1]
+        assert call_kwargs["extra_body"]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in call_kwargs
+
+    def test_parse_response_includes_cache_usage_tokens(self):
+        provider = AnthropicProvider(api_key="test-key")
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(
+                input_tokens=10,
+                cache_read_input_tokens=100,
+                cache_creation_input_tokens=20,
+                cache_creation=SimpleNamespace(
+                    ephemeral_5m_input_tokens=12,
+                    ephemeral_1h_input_tokens=8,
+                ),
+                output_tokens=5,
+            ),
+        )
+
+        response = provider._parse_response(response_obj)
+
+        assert response.usage == {
+            "prompt_tokens": 130,
+            "completion_tokens": 5,
+            "total_tokens": 135,
+            "cache_read_tokens": 100,
+            "cache_creation_tokens": 20,
+            "cache_creation_5m_tokens": 12,
+            "cache_creation_1h_tokens": 8,
+        }
+
+    def test_parse_response_includes_cache_hit_only_usage_tokens(self):
+        provider = AnthropicProvider(api_key="test-key")
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(
+                input_tokens=3,
+                cache_read_input_tokens=10988,
+                cache_creation_input_tokens=0,
+                output_tokens=16,
+            ),
+        )
+
+        response = provider._parse_response(response_obj)
+
+        assert response.usage == {
+            "prompt_tokens": 10991,
+            "completion_tokens": 16,
+            "total_tokens": 11007,
+            "cache_read_tokens": 10988,
+        }
+
+
 class TestAnthropicStructuredOutputFallback:
     """Tests for Anthropic structured-output fallback behavior."""
 
@@ -489,6 +753,12 @@ class TestMockProvider:
         """Test capability check."""
         assert await mock_provider.supports("structured_output") is True
         assert await mock_provider.supports("streaming") is False
+
+    @pytest.mark.asyncio
+    async def test_prompt_caching_support_is_not_truthy_for_default_none(self):
+        """String-valued prompt-caching capability should not make default providers truthy."""
+        assert await OpenAIProvider(api_key="test-key").supports("prompt_caching") is False
+        assert await AnthropicProvider(api_key="test-key").supports("prompt_caching") is True
 
     @pytest.mark.asyncio
     async def test_doctor_healthy(self, mock_provider):
@@ -586,6 +856,90 @@ class TestOpenAIProviderRequestParams:
 
         assert captured_kwargs["timeout"] == 19
 
+    @pytest.mark.asyncio
+    async def test_prompt_cache_request_does_not_add_openai_cache_controls(self):
+        """OpenAI prompt caching is automatic; request cache controls must not be sent."""
+        provider = OpenAIProvider(api_key="test-key")
+
+        captured_kwargs: dict[str, object] = {}
+
+        async def create(**kwargs):
+            captured_kwargs.update(kwargs)
+            message = MagicMock(content="ok", tool_calls=None)
+            choice = MagicMock(message=message, finish_reason="stop")
+            usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+            return MagicMock(choices=[choice], usage=usage, model="gpt-5.4")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=create)
+        provider._client = mock_client
+
+        await provider.generate(
+            GenerateRequest(
+                model="gpt-5.4",
+                messages=[Message(role="user", content="test")],
+                prompt_cache=PromptCacheConfig(),
+            )
+        )
+
+        assert "prompt_cache" not in captured_kwargs
+        assert "cache_control" not in captured_kwargs
+        assert "extra_body" not in captured_kwargs
+
+    def test_parse_response_includes_openai_cached_token_telemetry(self):
+        provider = OpenAIProvider(api_key="test-key")
+        message = MagicMock(content="ok", tool_calls=None)
+        choice = MagicMock(message=message, finish_reason="stop")
+        response_obj = MagicMock(
+            choices=[choice],
+            usage=SimpleNamespace(
+                prompt_tokens=2000,
+                completion_tokens=100,
+                total_tokens=2100,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=1200),
+            ),
+            model="gpt-5.4",
+        )
+
+        response = provider._parse_response(response_obj)
+
+        assert response.usage == {
+            "prompt_tokens": 2000,
+            "completion_tokens": 100,
+            "total_tokens": 2100,
+            "cache_read_tokens": 1200,
+        }
+
+    def test_parse_response_omits_openai_cache_telemetry_when_missing_or_zero(self):
+        provider = OpenAIProvider(api_key="test-key")
+        message = MagicMock(content="ok", tool_calls=None)
+        choice = MagicMock(message=message, finish_reason="stop")
+
+        for usage in (
+            SimpleNamespace(prompt_tokens=10, completion_tokens=2, total_tokens=12),
+            SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=2,
+                total_tokens=12,
+                prompt_tokens_details=SimpleNamespace(),
+            ),
+            SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=2,
+                total_tokens=12,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        ):
+            response_obj = MagicMock(choices=[choice], usage=usage, model="gpt-5.4")
+
+            response = provider._parse_response(response_obj)
+
+            assert response.usage == {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 12,
+            }
+
 
 class TestProviderTransportDefaults:
     """Tests for provider-native timeout and retry configuration."""
@@ -653,6 +1007,260 @@ class TestProviderTransportDefaults:
         assert http_options.retry_options.attempts == 1
 
 
+class TestVertexPromptCaching:
+    """Tests for Vertex split-path prompt caching."""
+
+    @pytest.mark.asyncio
+    async def test_vertex_claude_path_passes_cache_control_through_extra_body(self):
+        provider = VertexAIProvider(default_model="claude-opus-4-6@20260301")
+        client = AsyncMock()
+        provider._claude_client = client
+
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6@20260301",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.messages.create = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                model="claude-opus-4-6@20260301",
+                messages=[Message(role="user", content="test")],
+                prompt_cache=PromptCacheConfig(),
+            )
+        )
+
+        call_kwargs = client.messages.create.await_args_list[0].kwargs
+        assert call_kwargs["extra_body"]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_vertex_gemini_path_passes_cached_content_in_config(self):
+        provider = VertexAIProvider(project="test-project", default_model="gemini-3.1-pro-preview")
+        client = MagicMock()
+        provider._gemini_client = client
+
+        response_obj = SimpleNamespace(
+            text="ok",
+            candidates=[],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=1200,
+                candidates_token_count=10,
+                total_token_count=1210,
+            ),
+        )
+        client.aio.models.generate_content = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="test",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/example",
+                ),
+            )
+        )
+
+        call_kwargs = client.aio.models.generate_content.await_args_list[0].kwargs
+        assert call_kwargs["config"]["cached_content"] == "cachedContents/example"
+
+    def test_vertex_claude_parse_response_includes_cache_usage_tokens(self):
+        provider = VertexAIProvider(default_model="claude-opus-4-6@20260301")
+        response_obj = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            model="claude-opus-4-6@20260301",
+            stop_reason="end_turn",
+            usage=SimpleNamespace(
+                input_tokens=10,
+                cache_read_input_tokens=100,
+                cache_creation_input_tokens=20,
+                output_tokens=5,
+            ),
+        )
+
+        response = provider._parse_claude_response(response_obj)
+
+        assert response.usage == {
+            "prompt_tokens": 130,
+            "completion_tokens": 5,
+            "total_tokens": 135,
+            "cache_read_tokens": 100,
+            "cache_creation_tokens": 20,
+        }
+
+    def test_vertex_gemini_parse_response_includes_cached_content_token_count(self):
+        provider = VertexAIProvider(project="test-project", default_model="gemini-3.1-pro-preview")
+        response_obj = SimpleNamespace(
+            text="ok",
+            candidates=[],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=1200,
+                candidates_token_count=10,
+                total_token_count=1210,
+                cached_content_token_count=900,
+            ),
+        )
+
+        response = provider._parse_response(response_obj)
+
+        assert response.usage == {
+            "prompt_tokens": 1200,
+            "completion_tokens": 10,
+            "total_tokens": 1210,
+            "cache_read_tokens": 900,
+        }
+
+    @pytest.mark.asyncio
+    async def test_vertex_gemini_creates_cached_content_when_name_is_missing(self):
+        provider = VertexAIProvider(project="test-project", default_model="gemini-3.1-pro-preview")
+        client = MagicMock()
+        provider._gemini_client = client
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/generated")
+        )
+        client.aio.models.generate_content = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                candidates=[],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=1200,
+                    candidates_token_count=10,
+                    total_token_count=1210,
+                ),
+            )
+        )
+
+        response = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        create_kwargs = client.aio.caches.create.await_args_list[0].kwargs
+        assert create_kwargs["config"]["contents"] == "stable context"
+        assert response.prompt_cache["cache_name"] == "cachedContents/generated"
+
+    @pytest.mark.asyncio
+    async def test_vertex_gemini_refreshes_and_deletes_cached_content(self):
+        provider = VertexAIProvider(project="test-project", default_model="gemini-3.1-pro-preview")
+        client = MagicMock()
+        provider._gemini_client = client
+
+        client.aio.caches.update = AsyncMock(return_value=SimpleNamespace())
+        client.aio.caches.delete = AsyncMock(return_value=None)
+        client.aio.models.generate_content = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                candidates=[],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=1200,
+                    candidates_token_count=10,
+                    total_token_count=1210,
+                ),
+            )
+        )
+
+        response = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/existing",
+                    refresh_ttl=True,
+                    delete_after=True,
+                ),
+            )
+        )
+
+        client.aio.caches.update.assert_awaited_once()
+        client.aio.caches.delete.assert_awaited_once_with(name="cachedContents/existing")
+        assert response.prompt_cache["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_vertex_gemini_stream_deletes_created_cache_after_success(self):
+        provider = VertexAIProvider(project="test-project", default_model="gemini-3.1-pro-preview")
+        client = MagicMock()
+        provider._gemini_client = client
+
+        async def stream_chunks():
+            yield SimpleNamespace(text="ok")
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/tmp")
+        )
+        client.aio.caches.delete = AsyncMock(return_value=None)
+        client.aio.models.generate_content_stream = AsyncMock(return_value=stream_chunks())
+
+        stream = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                stream=True,
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    delete_after=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        chunks = [chunk async for chunk in stream]
+
+        assert chunks[0].text == "ok"
+        assert chunks[-1].prompt_cache["deleted"] is True
+        client.aio.caches.delete.assert_awaited_once_with(name="cachedContents/tmp")
+
+    @pytest.mark.asyncio
+    async def test_stream_does_not_retry_expiry_after_partial_output(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        async def failing_stream():
+            yield SimpleNamespace(text="partial")
+            raise RuntimeError("cached content expired")
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/tmp")
+        )
+        client.aio.caches.delete = AsyncMock(return_value=None)
+        client.aio.models.generate_content_stream = AsyncMock(return_value=failing_stream())
+
+        stream = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                stream=True,
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    delete_after=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        chunks = []
+        with pytest.raises(RuntimeError, match="cached content expired"):
+            async for chunk in stream:
+                chunks.append(chunk.text)
+
+        assert chunks == ["partial"]
+        client.aio.caches.create.assert_awaited_once()
+        client.aio.caches.delete.assert_awaited_once_with(name="cachedContents/tmp")
+
+
 class TestAnthropicProviderEnvModel:
     """Tests for ANTHROPIC_MODEL env var fallback in AnthropicProvider."""
 
@@ -704,6 +1312,347 @@ class TestGeminiProviderEnvModel:
         monkeypatch.setenv("GOOGLE_MODEL", "gemini-3-flash-preview")
         provider = GeminiProvider(default_model="gemini-3.1-pro-preview")
         assert provider._default_model == "gemini-3.1-pro-preview"
+
+
+class TestGeminiPromptCaching:
+    """Tests for Gemini cached-content passthrough."""
+
+    @pytest.mark.asyncio
+    async def test_generate_passes_cached_content_name_in_config(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        response_obj = SimpleNamespace(
+            text="ok",
+            candidates=[],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=1200,
+                candidates_token_count=10,
+                total_token_count=1210,
+            ),
+        )
+        client.aio.models.generate_content = AsyncMock(return_value=response_obj)
+
+        await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="test",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/example",
+                ),
+            )
+        )
+
+        call_kwargs = client.aio.models.generate_content.await_args_list[0].kwargs
+        assert call_kwargs["config"]["cached_content"] == "cachedContents/example"
+
+    @pytest.mark.asyncio
+    async def test_generate_without_prompt_cache_omits_cached_content(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        response_obj = SimpleNamespace(
+            text="ok",
+            candidates=[],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=1,
+                candidates_token_count=1,
+                total_token_count=2,
+            ),
+        )
+        client.aio.models.generate_content = AsyncMock(return_value=response_obj)
+
+        await provider.generate(GenerateRequest(model="gemini-3.1-pro-preview", prompt="test"))
+
+        call_kwargs = client.aio.models.generate_content.await_args_list[0].kwargs
+        assert call_kwargs["config"] is None
+
+    def test_parse_response_includes_cached_content_token_count(self):
+        provider = GeminiProvider(api_key="test-key")
+        response_obj = SimpleNamespace(
+            text="ok",
+            candidates=[],
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=1200,
+                candidates_token_count=10,
+                total_token_count=1210,
+                cached_content_token_count=900,
+            ),
+        )
+
+        response = provider._parse_response(response_obj)
+
+        assert response.usage == {
+            "prompt_tokens": 1200,
+            "completion_tokens": 10,
+            "total_tokens": 1210,
+            "cache_read_tokens": 900,
+        }
+
+    @pytest.mark.asyncio
+    async def test_generate_creates_cached_content_when_name_is_missing(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/generated")
+        )
+        client.aio.models.generate_content = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                candidates=[],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=1200,
+                    candidates_token_count=10,
+                    total_token_count=1210,
+                    cached_content_token_count=900,
+                ),
+            )
+        )
+
+        response = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    source_text="stable context",
+                    display_name="llm-council-test",
+                ),
+            )
+        )
+
+        create_kwargs = client.aio.caches.create.await_args_list[0].kwargs
+        assert create_kwargs["model"] == "gemini-3.1-pro-preview"
+        assert create_kwargs["config"]["contents"] == "stable context"
+        assert create_kwargs["config"]["display_name"] == "llm-council-test"
+        assert create_kwargs["config"]["ttl"] == "300s"
+        call_kwargs = client.aio.models.generate_content.await_args_list[0].kwargs
+        assert call_kwargs["config"]["cached_content"] == "cachedContents/generated"
+        assert response.prompt_cache["cache_name"] == "cachedContents/generated"
+        assert response.prompt_cache["created"] is True
+        assert response.prompt_cache["billing_warning"]
+
+    @pytest.mark.asyncio
+    async def test_generate_refreshes_ttl_for_existing_cached_content(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        client.aio.caches.update = AsyncMock(return_value=SimpleNamespace())
+        client.aio.models.generate_content = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                candidates=[],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=1200,
+                    candidates_token_count=10,
+                    total_token_count=1210,
+                ),
+            )
+        )
+
+        await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/existing",
+                    refresh_ttl=True,
+                    ttl="1h",
+                ),
+            )
+        )
+
+        update_kwargs = client.aio.caches.update.await_args_list[0].kwargs
+        assert update_kwargs["name"] == "cachedContents/existing"
+        assert update_kwargs["config"]["ttl"] == "3600s"
+
+    @pytest.mark.asyncio
+    async def test_generate_deletes_created_cache_after_success(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/tmp")
+        )
+        client.aio.caches.delete = AsyncMock(return_value=None)
+        client.aio.models.generate_content = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                candidates=[],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=1200,
+                    candidates_token_count=10,
+                    total_token_count=1210,
+                ),
+            )
+        )
+
+        response = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    delete_after=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        client.aio.caches.delete.assert_awaited_once_with(name="cachedContents/tmp")
+        assert response.prompt_cache["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_generate_warns_when_cache_cleanup_fails(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/tmp")
+        )
+        client.aio.caches.delete = AsyncMock(side_effect=RuntimeError("delete denied"))
+        client.aio.models.generate_content = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                candidates=[],
+                usage_metadata=SimpleNamespace(
+                    prompt_token_count=1200,
+                    candidates_token_count=10,
+                    total_token_count=1210,
+                ),
+            )
+        )
+
+        response = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    delete_after=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        assert response.prompt_cache["deleted"] is False
+        assert "cleanup failed" in response.prompt_cache["warnings"][0]
+
+    @pytest.mark.asyncio
+    async def test_generate_recreates_expired_cached_content_once(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/recreated")
+        )
+        client.aio.models.generate_content = AsyncMock(
+            side_effect=[
+                RuntimeError("cached content expired"),
+                SimpleNamespace(
+                    text="ok",
+                    candidates=[],
+                    usage_metadata=SimpleNamespace(
+                        prompt_token_count=1200,
+                        candidates_token_count=10,
+                        total_token_count=1210,
+                    ),
+                ),
+            ]
+        )
+
+        response = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/old",
+                    create_if_missing=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        assert client.aio.models.generate_content.await_count == 2
+        assert response.prompt_cache["cache_name"] == "cachedContents/recreated"
+        assert response.prompt_cache["recreated_after_expiry"] is True
+
+    @pytest.mark.asyncio
+    async def test_stream_deletes_created_cache_after_success(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        async def stream_chunks():
+            yield SimpleNamespace(text="ok")
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/tmp")
+        )
+        client.aio.caches.delete = AsyncMock(return_value=None)
+        client.aio.models.generate_content_stream = AsyncMock(return_value=stream_chunks())
+
+        stream = await provider.generate(
+            GenerateRequest(
+                model="gemini-3.1-pro-preview",
+                prompt="question",
+                stream=True,
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    create_if_missing=True,
+                    delete_after=True,
+                    source_text="stable context",
+                ),
+            )
+        )
+
+        chunks = [chunk async for chunk in stream]
+
+        assert chunks[0].text == "ok"
+        assert chunks[-1].prompt_cache["deleted"] is True
+        client.aio.caches.delete.assert_awaited_once_with(name="cachedContents/tmp")
+
+    @pytest.mark.asyncio
+    async def test_generate_deletes_created_cache_after_generation_failure(self):
+        provider = GeminiProvider(api_key="test-key")
+        client = MagicMock()
+        provider._client = client
+
+        client.aio.caches.create = AsyncMock(
+            return_value=SimpleNamespace(name="cachedContents/tmp")
+        )
+        client.aio.caches.delete = AsyncMock(return_value=None)
+        client.aio.models.generate_content = AsyncMock(side_effect=RuntimeError("network failed"))
+
+        with pytest.raises(RuntimeError, match="network failed"):
+            await provider.generate(
+                GenerateRequest(
+                    model="gemini-3.1-pro-preview",
+                    prompt="question",
+                    prompt_cache=PromptCacheConfig(
+                        mode="cached_content",
+                        create_if_missing=True,
+                        delete_after=True,
+                        source_text="stable context",
+                    ),
+                )
+            )
+
+        client.aio.caches.delete.assert_awaited_once_with(name="cachedContents/tmp")
 
 
 class TestGeminiCLIProviderDoctor:
@@ -1697,3 +2646,92 @@ class TestOpenRouterProviderEnvModel:
         )
 
         assert body["reasoning_effort"] == "high"
+
+    def test_build_request_body_adds_cache_control_for_anthropic_routes(self):
+        """OpenRouter cache controls are passed only for known Anthropic routes."""
+        provider = OpenRouterProvider(api_key="sk-or-test")
+
+        body = provider._build_request_body(
+            GenerateRequest(
+                model="anthropic/claude-opus-4-6",
+                prompt="test",
+                prompt_cache=PromptCacheConfig(ttl="1h"),
+            )
+        )
+
+        assert body["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_build_request_body_omits_cache_control_for_unsupported_routes(self):
+        """Direct adapter calls should not leak cache controls to unsupported routes."""
+        provider = OpenRouterProvider(api_key="sk-or-test")
+
+        body = provider._build_request_body(
+            GenerateRequest(
+                model="openai/gpt-5.4",
+                prompt="test",
+                prompt_cache=PromptCacheConfig(),
+            )
+        )
+
+        assert "cache_control" not in body
+
+    def test_parse_response_includes_openrouter_cache_telemetry(self):
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        data = {
+            "model": "anthropic/claude-opus-4-6",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 2000,
+                "completion_tokens": 100,
+                "total_tokens": 2100,
+                "prompt_tokens_details": {"cached_tokens": 1200},
+                "cache_write_tokens": 800,
+            },
+        }
+
+        response = provider._parse_response(data)
+
+        assert response.usage == {
+            "prompt_tokens": 2000,
+            "completion_tokens": 100,
+            "total_tokens": 2100,
+            "cache_read_tokens": 1200,
+            "cache_creation_tokens": 800,
+        }
+
+    def test_parse_response_tolerates_missing_or_malformed_openrouter_usage(self):
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        base_data = {
+            "model": "anthropic/claude-opus-4-6",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "ok"},
+                }
+            ],
+        }
+
+        assert provider._parse_response(base_data).usage is None
+
+        malformed = {
+            **base_data,
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+                "prompt_tokens_details": "unexpected",
+            },
+        }
+
+        response = provider._parse_response(malformed)
+
+        assert response.usage == {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        }

--- a/tests/test_request_compiler.py
+++ b/tests/test_request_compiler.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from llm_council.providers.base import GenerateRequest, ReasoningConfig, StructuredOutputConfig
+from llm_council.providers.base import (
+    GenerateRequest,
+    PromptCacheConfig,
+    ReasoningConfig,
+    StructuredOutputConfig,
+)
 from llm_council.providers.compiler import compile_request_for_provider
 
 
@@ -97,6 +102,191 @@ class TestRequestCompiler:
         assert ("temperature", "transformed") in actions
         assert ("top_p", "dropped") in actions
         assert ("tool_choice", "dropped") in actions
+
+    def test_anthropic_keeps_automatic_prompt_cache_config(self):
+        compiled = compile_request_for_provider(
+            "anthropic",
+            GenerateRequest(
+                prompt="test",
+                model="claude-opus-4-6",
+                prompt_cache=PromptCacheConfig(ttl="1h"),
+            ),
+        )
+
+        assert compiled.request.prompt_cache is not None
+        assert compiled.request.prompt_cache.ttl == "1h"
+        actions = {(decision.option, decision.action) for decision in compiled.decisions}
+        assert ("prompt_cache", "supported") in actions
+
+    def test_non_cache_control_providers_drop_prompt_cache_config(self):
+        for provider, model in (
+            ("openai", "gpt-5.4"),
+            ("gemini", "gemini-3.1-pro-preview"),
+            ("vertex-ai", "gemini-3.1-pro-preview"),
+        ):
+            compiled = compile_request_for_provider(
+                provider,
+                GenerateRequest(
+                    prompt="test",
+                    model=model,
+                    prompt_cache=PromptCacheConfig(),
+                ),
+            )
+
+            assert compiled.request.prompt_cache is None
+            assert any(
+                decision.option == "prompt_cache" and decision.action == "dropped"
+                for decision in compiled.decisions
+            )
+
+    def test_openrouter_keeps_prompt_cache_for_anthropic_routes(self):
+        compiled = compile_request_for_provider(
+            "openrouter",
+            GenerateRequest(
+                prompt="test",
+                model="anthropic/claude-opus-4-6",
+                prompt_cache=PromptCacheConfig(ttl="1h"),
+            ),
+        )
+
+        assert compiled.request.prompt_cache is not None
+        assert compiled.request.prompt_cache.ttl == "1h"
+        assert any(
+            decision.option == "prompt_cache" and decision.action == "supported"
+            for decision in compiled.decisions
+        )
+
+    def test_openrouter_drops_prompt_cache_for_unsupported_routes(self):
+        compiled = compile_request_for_provider(
+            "openrouter",
+            GenerateRequest(
+                prompt="test",
+                model="openai/gpt-5.4",
+                prompt_cache=PromptCacheConfig(),
+            ),
+        )
+
+        assert compiled.request.prompt_cache is None
+        assert any(
+            decision.option == "prompt_cache"
+            and decision.action == "dropped"
+            and "route-dependent" in decision.detail
+            for decision in compiled.decisions
+        )
+
+    def test_openrouter_virtual_provider_names_keep_prompt_cache_for_anthropic_routes(self):
+        compiled = compile_request_for_provider(
+            "anthropic/claude-opus-4-6",
+            GenerateRequest(
+                prompt="test",
+                model="anthropic/claude-opus-4-6",
+                prompt_cache=PromptCacheConfig(),
+            ),
+        )
+
+        assert compiled.request.prompt_cache is not None
+        assert any(
+            decision.option == "prompt_cache" and decision.action == "supported"
+            for decision in compiled.decisions
+        )
+
+    def test_gemini_keeps_cached_content_prompt_cache(self):
+        compiled = compile_request_for_provider(
+            "gemini",
+            GenerateRequest(
+                prompt="test",
+                model="gemini-3.1-pro-preview",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/example",
+                ),
+            ),
+        )
+
+        assert compiled.request.prompt_cache is not None
+        assert compiled.request.prompt_cache.mode == "cached_content"
+        assert any(
+            decision.option == "prompt_cache" and decision.action == "supported"
+            for decision in compiled.decisions
+        )
+
+    def test_gemini_drops_automatic_prompt_cache_request_controls(self):
+        compiled = compile_request_for_provider(
+            "gemini",
+            GenerateRequest(
+                prompt="test",
+                model="gemini-3.1-pro-preview",
+                prompt_cache=PromptCacheConfig(),
+            ),
+        )
+
+        assert compiled.request.prompt_cache is None
+        assert any(
+            decision.option == "prompt_cache"
+            and decision.action == "dropped"
+            and "cached-content" in decision.detail
+            for decision in compiled.decisions
+        )
+
+    def test_vertex_keeps_prompt_cache_for_split_paths(self):
+        claude = compile_request_for_provider(
+            "vertex-ai",
+            GenerateRequest(
+                prompt="test",
+                model="claude-opus-4-6@20260301",
+                prompt_cache=PromptCacheConfig(),
+            ),
+        )
+        gemini = compile_request_for_provider(
+            "vertex-ai",
+            GenerateRequest(
+                prompt="test",
+                model="gemini-3.1-pro-preview",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/example",
+                ),
+            ),
+        )
+
+        assert claude.request.prompt_cache is not None
+        assert gemini.request.prompt_cache is not None
+        actions = {(decision.option, decision.action) for decision in claude.decisions}
+        assert ("prompt_cache", "supported") in actions
+        actions = {(decision.option, decision.action) for decision in gemini.decisions}
+        assert ("prompt_cache", "supported") in actions
+
+    def test_vertex_drops_incompatible_prompt_cache_modes_for_split_paths(self):
+        claude = compile_request_for_provider(
+            "vertex-ai",
+            GenerateRequest(
+                prompt="test",
+                model="claude-opus-4-6@20260301",
+                prompt_cache=PromptCacheConfig(
+                    mode="cached_content",
+                    cached_content_name="cachedContents/example",
+                ),
+            ),
+        )
+        gemini = compile_request_for_provider(
+            "vertex-ai",
+            GenerateRequest(
+                prompt="test",
+                model="gemini-3.1-pro-preview",
+                prompt_cache=PromptCacheConfig(),
+            ),
+        )
+
+        assert claude.request.prompt_cache is None
+        assert gemini.request.prompt_cache is None
+        assert any(
+            decision.option == "prompt_cache" and decision.action == "dropped"
+            for decision in claude.decisions
+        )
+        assert any(
+            decision.option == "prompt_cache" and decision.action == "dropped"
+            for decision in gemini.decisions
+        )
 
     def test_gemini_drops_tooling_and_ignores_reasoning_effort(self):
         compiled = compile_request_for_provider(

--- a/uv.lock
+++ b/uv.lock
@@ -1262,7 +1262,7 @@ wheels = [
 
 [[package]]
 name = "the-llm-council"
-version = "0.7.17"
+version = "0.7.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Adds provider-specific prompt-cache support across Anthropic, OpenRouter, OpenAI telemetry, Gemini API, and Vertex Gemini.
- Adds Gemini/Vertex cached-content lifecycle handling: create, TTL refresh, expiry handling, best-effort cleanup, billing warnings, and metadata.
- Bumps package/docs/skill metadata to 0.7.18 and adds release notes plus prompt-cache provider docs.

## Live proof
- OpenRouter: second identical call returned cache_read_tokens=8116.
- Gemini API: created cachedContents/..., returned cache_read_tokens=12603, deleted successfully.
- Vertex Gemini: created projects/.../cachedContents/..., returned cache_read_tokens=14002, deleted successfully.

## Validation
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy src
- PYTHONPATH=src uv run pytest -q (431 passed, 2 google-genai deprecation warnings)
- uv build produced dist/the_llm_council-0.7.18.tar.gz and dist/the_llm_council-0.7.18-py3-none-any.whl
- Isolated wheel install smoke passed: council version => 0.7.18
- Installed local tool doctor passed for openrouter, gemini, vertex-ai

## Release note
After merge to main, publish GitHub release v0.7.18 to trigger the existing PyPI trusted-publishing workflow.