### PR TITLE
fix(openrouter): strip unsupported number-range keywords from structured-output schemas

### DIFF
--- a/src/llm_council/providers/openrouter.py
+++ b/src/llm_council/providers/openrouter.py
@@ -37,11 +37,33 @@ OPENROUTER_CACHE_CONTROL_MODEL_PREFIXES = ("anthropic/",)
 logger = logging.getLogger(__name__)
 
 
+# JSON-Schema validation keywords that some providers' structured-output
+# enforcement rejects. Anthropic (and the Azure/OpenAI fallback) return a 400
+# such as "output_config.format.schema: For 'number' type, properties maximum,
+# minimum are not supported". OpenRouter forwards the schema untouched, so a
+# single unsupported keyword makes every structured call to those providers
+# fail; when such a model is the only/critique model the whole run dies with
+# "Below minimum required providers (1)". We drop the keywords here — they only
+# constrain values, not the JSON shape, so removing them preserves semantics.
+_UNSUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "$schema",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+    }
+)
+
+
 def _strip_schema_metadata(value: Any) -> Any:
     """Recursively remove metadata keys that OpenRouter/OpenAI ignore or reject."""
     if isinstance(value, dict):
         return {
-            key: _strip_schema_metadata(item) for key, item in value.items() if key != "$schema"
+            key: _strip_schema_metadata(item)
+            for key, item in value.items()
+            if key not in _UNSUPPORTED_SCHEMA_KEYS
         }
     if isinstance(value, list):
         return [_strip_schema_metadata(item) for item in value]

--- a/tests/unit/test_openrouter_schema_strip.py
+++ b/tests/unit/test_openrouter_schema_strip.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from llm_council.providers.openrouter import (
+    _prepare_structured_output_schema,
+    _strip_schema_metadata,
+)
+
+
+def test_strip_removes_number_range_keywords() -> None:
+    """Anthropic/OpenAI structured output rejects minimum/maximum on numbers.
+
+    OpenRouter forwards the schema untouched, so these keywords must be stripped
+    or every structured call to those providers 400s (and a single/critique
+    model failing surfaces as "Below minimum required providers (1)").
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 10,
+                "multipleOf": 0.1,
+            }
+        },
+        "required": ["score"],
+        "additionalProperties": False,
+    }
+
+    stripped = _strip_schema_metadata(schema)
+    score = stripped["properties"]["score"]
+
+    assert score == {"type": "number"}
+    for keyword in ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"):
+        assert keyword not in score
+
+
+def test_strip_removes_nested_and_array_range_keywords() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {"type": "integer", "minimum": 1, "maximum": 100},
+            }
+        },
+    }
+
+    stripped = _strip_schema_metadata(schema)
+    item_schema = stripped["properties"]["items"]["items"]
+
+    assert item_schema == {"type": "integer"}
+
+
+def test_strip_preserves_shape_keywords() -> None:
+    """Only value constraints are dropped; structural keywords stay intact."""
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": False,
+    }
+
+    stripped = _strip_schema_metadata(schema)
+
+    assert stripped["type"] == "object"
+    assert stripped["required"] == ["name"]
+    assert stripped["additionalProperties"] is False
+    assert stripped["properties"]["name"] == {"type": "string"}
+
+
+def test_prepare_structured_output_schema_drops_range_keywords() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"score": {"type": "number", "minimum": 0, "maximum": 1}},
+        "required": ["score"],
+        "additionalProperties": False,
+    }
+
+    prepared, strict_mode = _prepare_structured_output_schema(schema, strict=True)
+
+    assert "minimum" not in prepared["properties"]["score"]
+    assert "maximum" not in prepared["properties"]["score"]
+    # A fully-required, closed object with the range keywords gone stays strict-compatible.
+    assert strict_mode is True


### PR DESCRIPTION
## Problem

`council run` dies reproducibly with a `400 Bad Request` from OpenRouter followed by `Below minimum required providers (1)`.

Root cause: the subagent output schemas (e.g. `ReviewerOutput`) declare `number` fields with `minimum`/`maximum` bounds (scores, confidence). Anthropic's structured-output enforcement — and the Azure/OpenAI fallback route — reject those keywords:

```
output_config.format.schema: For 'number' type, properties maximum, minimum are not supported
```

`_build_request_body` forwards the schema to OpenRouter untouched via `response_format: json_schema`, so **every** structured-output call to an affected provider 400s. With a multi-model pack the run degrades silently; when the sole or critique model routes through such a provider, degradation exhausts and the whole run fails with `Below minimum required providers (1)`.

Reproduced deterministically (4/4) against `anthropic/claude-opus-4-6` via OpenRouter with a schema containing `{"type": "number", "minimum": 0, "maximum": 1}`.

## Fix

`_strip_schema_metadata` previously removed only `$schema`. This PR extends it to also drop the JSON-Schema *value* constraints that these providers reject:

- `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`

These keywords constrain values, not the JSON shape, so removing them preserves the schema's `type` / `required` / `additionalProperties` semantics — and keeps it strict-compatible for `_schema_is_strict_compatible`. After the fix the same schema is accepted by all three routes (Anthropic, OpenAI, Gemini).

## Tests

Adds `tests/unit/test_openrouter_schema_strip.py`:

- range keywords stripped from a `number` property
- stripping recurses into nested/array schemas
- structural keywords (`type`/`required`/`additionalProperties`) preserved
- `_prepare_structured_output_schema` drops the keywords and the result stays strict-compatible

All four pass locally against the patched module.

## Notes

There is a second, independent Anthropic-only limit not addressed here — the structured-output grammar caps optional parameters at 24, and some subagent schemas exceed that (`Schemas contains too many optional parameters`). That failure is currently absorbed by graceful degradation (the run still succeeds via prompt-based JSON), so it is out of scope for this PR, but worth a follow-up if you want Anthropic to participate in structured output for those subagents.